### PR TITLE
Introduce NiceGUI interface and simulation controller

### DIFF
--- a/keyboard_input_handler.py
+++ b/keyboard_input_handler.py
@@ -120,35 +120,7 @@ class KeyboardInputHandler:
             if key == glfw.KEY_U: self.state.serial_is_connected = self.serial_comm_ref.scan_and_connect(); return
             if key == glfw.KEY_J: self.state.gamepad_is_connected = self.xbox_handler.scan_and_connect(); return
             
-            # --- 模式切換快捷鍵 ---
-            if key == glfw.KEY_F: self.state.set_control_mode("FLOATING" if self.state.control_mode == "WALKING" else "WALKING"); return
-            if key == glfw.KEY_B: self.state.set_control_mode("MANUAL_CTRL" if self.state.control_mode != "MANUAL_CTRL" else "WALKING"); return
-            if key == glfw.KEY_H: self.state.set_control_mode("HARDWARE_MODE" if self.state.control_mode != "HARDWARE_MODE" else "WALKING"); return
-            if key == glfw.KEY_G:
-                if self.state.hardware_controller_ref and self.state.hardware_controller_ref.is_running:
-                    self.state.set_control_mode("JOINT_TEST")
-                else:
-                    self.state.set_control_mode("JOINT_TEST" if self.state.control_mode != "JOINT_TEST" else "WALKING")
-                return
-            
-            # --- 硬體模式專用快捷鍵 ---
-            if key == glfw.KEY_K:
-                if self.state.control_mode == "HARDWARE_MODE" and self.state.hardware_controller_ref:
-                    if self.state.hardware_ai_is_active: self.state.hardware_controller_ref.disable_ai()
-                    else: self.state.hardware_controller_ref.enable_ai()
-                else: print("Please enter Hardware Mode by pressing 'H' first.")
-                return
-
-            # --- 策略模型選擇快捷鍵 ---
-            policy_keys = { glfw.KEY_1: 0, glfw.KEY_2: 1, glfw.KEY_3: 2, glfw.KEY_4: 3, glfw.KEY_5: 4, glfw.KEY_6: 5 }
-            if key in policy_keys:
-                target_index = policy_keys[key]
-                if self.state.policy_manager_ref and self.state.available_policies:
-                    if target_index < len(self.state.available_policies):
-                        target_policy_name = self.state.available_policies[target_index]
-                        self.state.policy_manager_ref.select_target_policy(target_policy_name)
-                    else: print(f"⚠️ 警告: 策略索引 {target_index+1} 超出範圍。")
-                return
+            # 模式切換等功能已移至 GUI，保留鍵盤僅做基礎操作
 
         # --- 長按事件 (重複觸發) ---
         if action in [glfw.PRESS, glfw.REPEAT]:

--- a/keyboard_input_handler.py
+++ b/keyboard_input_handler.py
@@ -21,8 +21,8 @@ class KeyboardInputHandler:
 
     def char_callback(self, window, codepoint):
         """處理可列印字元的輸入，專門用於序列埠模式。"""
-        if self.state.control_mode == "SERIAL_MODE": # 檢查是否處於序列埠模式
-            self.state.serial_command_buffer += chr(codepoint) # 將輸入的字元附加到指令緩衝區
+        if self.state.control_mode == "SERIAL_MODE":
+            pass
 
     def key_callback(self, window, key, scancode, action, mods):
         """【最終重構】處理所有按鍵事件，為所有專用模式建立壁壘。"""
@@ -44,17 +44,9 @@ class KeyboardInputHandler:
 
     def handle_serial_mode_keys(self, key, action):
         """專門處理序列埠模式下的按鍵。"""
-        if key == glfw.KEY_GRAVE_ACCENT and action == glfw.PRESS: # 如果按下 `~` 鍵
-            # 【智慧退出】退出時，返回到進入此模式前的上一個模式
+        if key == glfw.KEY_GRAVE_ACCENT and action == glfw.PRESS:
             self.state.set_control_mode(self.state.previous_control_mode)
             return
-            
-        if action in [glfw.PRESS, glfw.REPEAT]: # 處理按下或長按
-            if key == glfw.KEY_ENTER: # 如果是 Enter 鍵
-                self.state.serial_command_to_send = self.state.serial_command_buffer # 將緩衝區內容設為待發送
-                self.state.serial_command_buffer = "" # 清空緩衝區
-            elif key == glfw.KEY_BACKSPACE: # 如果是 Backspace 鍵
-                self.state.serial_command_buffer = self.state.serial_command_buffer[:-1] # 刪除最後一個字元
 
     def handle_joint_test_mode_keys(self, key, action):
         """專門處理關節測試模式下的按鍵，只更新狀態，不發送指令。"""

--- a/keyboard_input_handler.py
+++ b/keyboard_input_handler.py
@@ -1,6 +1,7 @@
 # keyboard_input_handler.py
 import glfw
 from state import SimulationState
+from logger import log
 
 class KeyboardInputHandler:
     """處理所有鍵盤輸入事件，並根據當前模式進行分派。"""
@@ -22,7 +23,8 @@ class KeyboardInputHandler:
     def char_callback(self, window, codepoint):
         """處理可列印字元的輸入，專門用於序列埠模式。"""
         if self.state.control_mode == "SERIAL_MODE":
-            pass
+            # 在序列埠模式下，將輸入的字元加入指令緩衝區
+            self.state.serial_command_buffer += chr(codepoint)
 
     def key_callback(self, window, key, scancode, action, mods):
         """【最終重構】處理所有按鍵事件，為所有專用模式建立壁壘。"""
@@ -47,6 +49,13 @@ class KeyboardInputHandler:
         if key == glfw.KEY_GRAVE_ACCENT and action == glfw.PRESS:
             self.state.set_control_mode(self.state.previous_control_mode)
             return
+        if action in [glfw.PRESS, glfw.REPEAT]:
+            if key == glfw.KEY_ENTER:
+                log.info(f"[UI > Serial]: {self.state.serial_command_buffer}")
+                self.serial_comm_ref.send_command(self.state.serial_command_buffer)
+                self.state.serial_command_buffer = ""
+            elif key == glfw.KEY_BACKSPACE:
+                self.state.serial_command_buffer = self.state.serial_command_buffer[:-1]
 
     def handle_joint_test_mode_keys(self, key, action):
         """專門處理關節測試模式下的按鍵，只更新狀態，不發送指令。"""
@@ -116,8 +125,21 @@ class KeyboardInputHandler:
 
         # --- 長按事件 (重複觸發) ---
         if action in [glfw.PRESS, glfw.REPEAT]:
-            if self.state.input_mode != "KEYBOARD": return
-            
+            step = self.config.keyboard_velocity_adjust_step
+            with self.state.lock:
+                if key == glfw.KEY_Q: 
+                    self.state.command[2] += step
+                    return
+                elif key == glfw.KEY_E:
+                    self.state.command[2] -= step
+                    return
+                elif key == glfw.KEY_C:
+                    self.state.clear_command()
+                    return
+
+            if self.state.input_mode != "KEYBOARD":
+                return
+
             # 參數調整
             if key == glfw.KEY_LEFT_BRACKET: self.state.tuning_param_index = (self.state.tuning_param_index - 1) % self.num_params
             elif key == glfw.KEY_RIGHT_BRACKET: self.state.tuning_param_index = (self.state.tuning_param_index + 1) % self.num_params
@@ -133,10 +155,8 @@ class KeyboardInputHandler:
             
             # 移動指令
             step = self.config.keyboard_velocity_adjust_step
-            if key == glfw.KEY_C: self.state.clear_command()
-            elif key == glfw.KEY_W: self.state.command[1] += step
+            if key == glfw.KEY_W: self.state.command[1] += step
             elif key == glfw.KEY_S: self.state.command[1] -= step
             elif key == glfw.KEY_A: self.state.command[0] += step
             elif key == glfw.KEY_D: self.state.command[0] -= step
-            elif key == glfw.KEY_Q: self.state.command[2] += step
-            elif key == glfw.KEY_E: self.state.command[2] -= step
+            

--- a/logger.py
+++ b/logger.py
@@ -1,0 +1,26 @@
+import logging
+from collections import deque
+from typing import Deque
+
+# A bounded deque to store log messages
+log_queue: Deque[str] = deque(maxlen=500)
+
+class QueueHandler(logging.Handler):
+    """Logging handler that stores logs in a global queue."""
+    def emit(self, record: logging.LogRecord) -> None:
+        log_entry = self.format(record)
+        log_queue.append(log_entry)
+
+
+def setup_logger() -> logging.Logger:
+    logger = logging.getLogger("RobotLogger")
+    logger.setLevel(logging.INFO)
+    if not logger.handlers:
+        handler = QueueHandler()
+        formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s',
+                                      datefmt='%H:%M:%S')
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    return logger
+
+log = setup_logger()

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ def main():
     config = load_config()
     state = SimulationState(config)
     sim = Simulation(config)
-    
+
     # --- 2. 【核心修改】將核心物件的參考存入 state，使其成為全域上下文 ---
     state.sim = sim
     
@@ -43,8 +43,9 @@ def main():
     xbox_handler = XboxInputHandler(state)
 
     obs_builder = ObservationBuilder(sim.data, sim.model, sim.torso_id, sim.default_pose, config)
+    # 在無 GUI 版本中仍建立 DebugOverlay 以顯示文字資訊
     overlay = DebugOverlay()
-    
+
     policy_manager = PolicyManager(config, obs_builder, overlay)
     state.policy_manager_ref = policy_manager
     state.available_policies = policy_manager.model_names
@@ -54,8 +55,11 @@ def main():
     state.hardware_controller_ref = hw_controller
 
     # KeyboardInputHandler 不再需要直接傳入 serial_comm
-    keyboard_handler = KeyboardInputHandler(state, xbox_handler, terrain_manager) 
-    keyboard_handler.register_callbacks(sim.window)
+    keyboard_handler = KeyboardInputHandler(state, xbox_handler, terrain_manager)
+    # 先註冊回呼，待初始化視窗後會正式生效
+    sim.register_callbacks(keyboard_handler)
+    # 初始化 GLFW 視窗與渲染上下文
+    sim.initialize_window_and_context()
 
     # --- 4. 定義重置函式 ---
     def hard_reset():
@@ -114,7 +118,7 @@ def main():
     # --- 6. 主模擬迴圈 ---
     while not sim.should_close():
         if state.single_step_mode and not state.execute_one_step:
-            sim.render(state, overlay)
+            sim.render(state)
             continue
         if state.execute_one_step: state.execute_one_step = False
 
@@ -169,7 +173,7 @@ def main():
             while sim.data.time < target_time:
                 mujoco.mj_step(sim.model, sim.data)
 
-        sim.render(state, overlay)
+        sim.render(state)
 
     # --- 7. 程式結束，清理資源 ---
     hw_controller.stop()

--- a/main.py
+++ b/main.py
@@ -144,12 +144,7 @@ def main():
                 state.hardware_status_text = "Hardware controller not running."
         
         elif state.control_mode == "SERIAL_MODE":
-            if state.serial_is_connected:
-                state.serial_latest_messages = serial_comm.get_latest_messages()
-            
-            if state.serial_command_to_send:
-                serial_comm.send_command(state.serial_command_to_send)
-                state.serial_command_to_send = ""
+            pass
         else: # 模擬模式 (WALKING, FLOATING, etc.)
             if state.single_step_mode: print("\n" + "="*20 + f" STEP AT TIME {sim.data.time:.4f} " + "="*20)
 

--- a/main_nicegui.py
+++ b/main_nicegui.py
@@ -1,0 +1,78 @@
+"""Entry point using NiceGUI for the control interface."""
+
+import sys
+import threading
+
+from config import load_config
+from state import SimulationState
+from simulation import Simulation
+from simulation_controller import SimulationController
+from ui_controller import UIController
+from policy import PolicyManager
+from observation import ObservationBuilder
+from floating_controller import FloatingController
+from serial_communicator import SerialCommunicator
+from terrain_manager import TerrainManager
+from hardware_controller import HardwareController
+from keyboard_input_handler import KeyboardInputHandler
+from xbox_input_handler import XboxInputHandler
+
+
+def main() -> None:
+    """Initialise all components and start UI and simulation threads."""
+
+    print("\n--- Robot Simulation Controller (NiceGUI edition) ---")
+
+    try:
+        config = load_config()
+        state = SimulationState(config)
+        sim = Simulation(config)
+    except Exception as exc:  # pragma: no cover - startup errors
+        sys.exit(f"failed to initialise: {exc}")
+
+    state.sim = sim
+
+    terrain_manager = TerrainManager(sim.model, sim.data)
+    state.terrain_manager_ref = terrain_manager
+
+    floating_controller = FloatingController(config, sim.model, sim.data, terrain_manager)
+    state.floating_controller_ref = floating_controller
+
+    serial_comm = SerialCommunicator()
+    state.serial_communicator_ref = serial_comm
+
+    xbox_handler = XboxInputHandler(state)
+    state.xbox_handler_ref = xbox_handler
+
+    obs_builder = ObservationBuilder(sim.data, sim.model, sim.torso_id, sim.default_pose, config)
+
+    policy_manager = PolicyManager(config, obs_builder, None)
+    state.policy_manager_ref = policy_manager
+    state.available_policies = policy_manager.model_names
+
+    hw_controller = HardwareController(config, policy_manager, state, serial_comm)
+    state.hardware_controller_ref = hw_controller
+
+    keyboard_handler = KeyboardInputHandler(state, xbox_handler, terrain_manager)
+    sim.register_callbacks(keyboard_handler)
+
+    simulation_controller = SimulationController(state)
+    ui_controller = UIController(state)
+
+    simulation_thread = threading.Thread(target=simulation_controller.run, daemon=True)
+    simulation_thread.start()
+
+    print("simulation thread started, launching UI ...")
+    ui_controller.run()
+
+    print("closing application ...")
+    simulation_controller.stop()
+    hw_controller.stop()
+    serial_comm.close()
+    xbox_handler.close()
+    sim.close()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/main_nicegui.py
+++ b/main_nicegui.py
@@ -1,7 +1,7 @@
 """Entry point using NiceGUI for the control interface."""
 
 import sys
-from nicegui import ui  # 從 nicegui 模組導入實例化的 ui 物件
+from nicegui import ui, app  # 從 nicegui 匯入 ui 物件與 app 實例
 
 from config import load_config
 from state import SimulationState
@@ -57,23 +57,32 @@ def main() -> None:
     sim.register_callbacks(keyboard_handler)
 
     simulation_controller = SimulationController(state)
-    ui_controller = UIController(state, simulation_controller)
+    ui_controller = UIController(state)
 
-    # 模擬執行緒將在 NiceGUI 完全啟動後啟動
-    print("launching UI; simulation thread will start once UI is ready...")
+    def start_simulation_thread() -> None:
+        """UI 啟動後啟動模擬執行緒。"""
+        print("NiceGUI 已啟動，現在安全地啟動模擬執行緒...")
+        thread = threading.Thread(target=simulation_controller.run, daemon=True)
+        thread.start()
+
+    def cleanup_resources() -> None:
+        """UI 關閉時釋放所有背景資源。"""
+        print("NiceGUI 正在關閉，正在清理資源...")
+        simulation_controller.stop()
+        hw_controller.stop()
+        serial_comm.close()
+        xbox_handler.close()
+        sim.close()
+        print("✅ 所有資源已成功釋放。")
+
+    app.on_startup(start_simulation_thread)
+    app.on_shutdown(cleanup_resources)
+
+    print("🚀 正在啟動 NiceGUI 控制台... 請打開您的瀏覽器。")
     ui.run(
         title="Pupper Robot Console",
         port=8080,
-        on_startup=ui_controller.handle_startup,
-        on_shutdown=ui_controller.handle_shutdown,
     )
-
-    print("closing application ...")
-    simulation_controller.stop()
-    hw_controller.stop()
-    serial_comm.close()
-    xbox_handler.close()
-    sim.close()
 
 
 if __name__ in {"__main__", "__mp_main__"}:

--- a/main_nicegui.py
+++ b/main_nicegui.py
@@ -1,7 +1,7 @@
 """Entry point using NiceGUI for the control interface."""
 
 import sys
-import nicegui as ui
+from nicegui import ui  # 從 nicegui 模組導入實例化的 ui 物件
 
 from config import load_config
 from state import SimulationState
@@ -76,6 +76,6 @@ def main() -> None:
     sim.close()
 
 
-if __name__ == "__main__":
+if __name__ in {"__main__", "__mp_main__"}:
     main()
 

--- a/main_nicegui.py
+++ b/main_nicegui.py
@@ -57,12 +57,10 @@ def main() -> None:
     sim.register_callbacks(keyboard_handler)
 
     simulation_controller = SimulationController(state)
-    ui_controller = UIController(state)
+    ui_controller = UIController(state, simulation_controller)
 
-    simulation_thread = threading.Thread(target=simulation_controller.run, daemon=True)
-    simulation_thread.start()
-
-    print("simulation thread started, launching UI ...")
+    # 模擬執行緒將在 NiceGUI 完全啟動後由 on_startup 事件啟動
+    print("launching UI (simulation thread will start on startup)...")
     ui_controller.run()
 
     print("closing application ...")

--- a/main_nicegui.py
+++ b/main_nicegui.py
@@ -1,7 +1,7 @@
 """Entry point using NiceGUI for the control interface."""
 
 import sys
-import threading
+import nicegui as ui
 
 from config import load_config
 from state import SimulationState
@@ -59,9 +59,14 @@ def main() -> None:
     simulation_controller = SimulationController(state)
     ui_controller = UIController(state, simulation_controller)
 
-    # 模擬執行緒將在 NiceGUI 完全啟動後由 on_startup 事件啟動
-    print("launching UI (simulation thread will start on startup)...")
-    ui_controller.run()
+    # 模擬執行緒將在 NiceGUI 完全啟動後啟動
+    print("launching UI; simulation thread will start once UI is ready...")
+    ui.run(
+        title="Pupper Robot Console",
+        port=8080,
+        on_startup=ui_controller.handle_startup,
+        on_shutdown=ui_controller.handle_shutdown,
+    )
 
     print("closing application ...")
     simulation_controller.stop()

--- a/main_nicegui.py
+++ b/main_nicegui.py
@@ -1,6 +1,7 @@
 """Entry point using NiceGUI for the control interface."""
 
 import sys
+import threading  # 新增：用於啟動模擬執行緒
 from nicegui import ui, app  # 從 nicegui 匯入 ui 物件與 app 實例
 
 from config import load_config

--- a/observation.py
+++ b/observation.py
@@ -1,14 +1,14 @@
 # observation.py
 import numpy as np
 import mujoco
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Dict
 
 if TYPE_CHECKING:
     from config import AppConfig
 
 class ObservationBuilder:
     def __init__(self, data, model, torso_id, default_pose, config: 'AppConfig'):
-        self.recipe = [] # 初始化為空，將由外部設定
+        self.recipe = []  # 初始化為空，將由外部設定
         self.data = data
         self.model = model
         self.torso_id = torso_id
@@ -21,12 +21,24 @@ class ObservationBuilder:
             print("⚠️ 警告: 在XML中找不到名為 'accelerometer' 的感測器。")
             self.accelerometer_id = -1
 
+        # 【核心修正】定義所有可能觀察元件的維度
+        self.ALL_OBS_DIMS: Dict[str, int] = {
+            'z_angular_velocity': 1, 'gravity_vector': 3, 'commands': 3,
+            'joint_positions': 12, 'joint_velocities': 12, 'foot_contact_states': 4,
+            'linear_velocity': 3, 'angular_velocity': 3, 'last_action': 12,
+            'phase_signal': 1, 'accelerometer': 3,
+        }
+        self.component_dims: Dict[str, int] = {}
+
         self._component_generators = self._register_components()
 
     def set_recipe(self, recipe: list):
         """動態設定當前要使用的觀察配方。"""
-        # print(f"  -> ObservationBuilder 切換配方至: {recipe}")
+        if self.recipe == recipe:
+            return
         self.recipe = recipe
+        # 【核心修正】更新 component_dims 字典
+        self.component_dims = {k: self.ALL_OBS_DIMS[k] for k in recipe if k in self.ALL_OBS_DIMS}
         for component in self.recipe:
             if component not in self._component_generators:
                 print(f"⚠️ 警告: 新配方中的元件 '{component}' 不存在，將被忽略。")

--- a/rendering.py
+++ b/rendering.py
@@ -25,12 +25,21 @@ class DebugOverlay:
 
     def set_recipe(self, recipe: List[str]):
         """動態設定當前要顯示的觀察配方。"""
+        # 若新配方與目前相同，直接返回，避免在每一幀都印出訊息
+        if recipe == self.recipe:
+            return
+
         self.recipe = recipe
-        ALL_OBS_DIMS = {'z_angular_velocity':1, 'gravity_vector':3, 'commands':3, 
-                        'joint_positions':12, 'joint_velocities':12, 'foot_contact_states':4, 
-                        'linear_velocity':3, 'angular_velocity':3, 'last_action':12, 
-                        'phase_signal':1, 'accelerometer': 3}
+        # 各個觀察向量元件的維度資訊
+        ALL_OBS_DIMS = {
+            'z_angular_velocity': 1, 'gravity_vector': 3, 'commands': 3,
+            'joint_positions': 12, 'joint_velocities': 12, 'foot_contact_states': 4,
+            'linear_velocity': 3, 'angular_velocity': 3, 'last_action': 12,
+            'phase_signal': 1, 'accelerometer': 3,
+        }
+        # 只保留在配方中的元件及其維度
         self.component_dims = {k: ALL_OBS_DIMS[k] for k in recipe if k in ALL_OBS_DIMS}
+        # 僅在配方改變時輸出提示文字
         print(f"  -> DebugOverlay 切換配方至: {self.recipe}")
 
     def render(self, viewport, context, state: SimulationState, sim: "Simulation"):

--- a/rendering.py
+++ b/rendering.py
@@ -133,13 +133,13 @@ class DebugOverlay:
         title = "--- SERIAL CONSOLE MODE (Press ~ to exit) ---"
         mujoco.mjr_overlay(mujoco.mjtFont.mjFONT_BIG, mujoco.mjtGridPos.mjGRID_TOPLEFT, console_rect, title, " ", context)
         
-        log_text = "\n".join(state.serial_latest_messages)
+        from logger import log_queue
+        log_text = "\n".join(list(log_queue)[-50:])
         log_rect = mujoco.MjrRect(console_rect.left + 10, console_rect.bottom, console_rect.width - 20, console_rect.height - 50)
         mujoco.mjr_overlay(mujoco.mjtFont.mjFONT_NORMAL, mujoco.mjtGridPos.mjGRID_TOPLEFT, log_rect, "\n\n" + log_text, " ", context)
 
-        cursor = "_" if int(time.time() * 2) % 2 == 0 else " "
-        buffer_text = f"> {state.serial_command_buffer}{cursor}"
-        mujoco.mjr_overlay(mujoco.mjtFont.mjFONT_NORMAL, mujoco.mjtGridPos.mjGRID_BOTTOMLEFT, console_rect, buffer_text, " ", context)
+        help_buf = "See NiceGUI console for input"
+        mujoco.mjr_overlay(mujoco.mjtFont.mjFONT_NORMAL, mujoco.mjtGridPos.mjGRID_BOTTOMLEFT, console_rect, help_buf, " ", context)
     
     def render_joint_test_overlay(self, viewport, context, state: SimulationState, sim: "Simulation"):
         """渲染關節手動測試模式的專用介面。"""

--- a/serial_communicator.py
+++ b/serial_communicator.py
@@ -6,6 +6,7 @@ import threading
 import serial.tools.list_ports
 from serial_utils import select_serial_port
 from collections import deque
+from logger import log
 
 class SerialCommunicator:
     """
@@ -14,14 +15,13 @@ class SerialCommunicator:
     """
     def __init__(self, max_log_lines=50): # 【容量加大】將日誌行數從 15 增加到 50
         """初始化通訊器。"""
-        self.ser = None # serial.Serial 物件，在連接成功後被賦值
-        self.read_thread = None # 用於讀取序列埠數據的背景執行緒
-        self.exit_signal = threading.Event() # 一個安全地停止背景執行緒的信號
-        self.is_connected = False # 標記當前是否已連接
-        self.port_name = None # 儲存已連接的序列埠名稱
-        self.message_log = deque(maxlen=max_log_lines) # 使用新的容量上限，建立一個固定長度的訊息佇列
-        self.is_managed_by_hardware_controller = False # 旗標，當為True時，表示連接由HardwareController管理，本類別暫停活動
-        print("✅ 序列埠通訊器已初始化 (等待連接指令)。")
+        self.ser = None
+        self.read_thread = None
+        self.exit_signal = threading.Event()
+        self.is_connected = False
+        self.port_name = None
+        self.is_managed_by_hardware_controller = False
+        log.info("序列埠通訊器已初始化 (等待連接指令)。")
 
     def get_serial_connection(self) -> serial.Serial | None:
         """返回已建立的 serial.Serial 物件，供 HardwareController 使用。"""
@@ -32,7 +32,7 @@ class SerialCommunicator:
     def scan_and_connect(self) -> bool:
         """掃描、讓使用者選擇並連接序列埠。"""
         if self.is_connected: # 如果已連接
-            print("序列埠已連接，無需重新掃描。")
+            log.info("序列埠已連接，無需重新掃描。")
             return True
             
         selected_port = self._select_serial_port() # 讓使用者選擇序列埠
@@ -49,7 +49,7 @@ class SerialCommunicator:
         """連接到指定的序列埠並啟動讀取執行緒。"""
         if not self.port_name: return False # 如果沒有埠名，返回失敗
         try:
-            print(f"正在連接到 {self.port_name}...")
+            log.info(f"正在連接到 {self.port_name}...")
             self.ser = serial.Serial(self.port_name, baud_rate, timeout=0.1) # 建立序列埠物件
             time.sleep(0.5) # 等待硬體初始化
             self.ser.reset_input_buffer() # 清空輸入緩衝區
@@ -59,10 +59,10 @@ class SerialCommunicator:
             self.read_thread = threading.Thread(target=self._read_from_port, daemon=True) # 建立讀取執行緒
             self.read_thread.start() # 啟動執行緒
             self.is_connected = True # 設定連接旗標
-            print(f"✅ 序列埠 {self.port_name} 連接成功。")
+            log.info(f"✅ 序列埠 {self.port_name} 連接成功。")
             return True
         except serial.SerialException as e: # 捕捉連接錯誤
-            print(f"❌ 序列埠連接失敗: {e}")
+            log.error(f"❌ 序列埠連接失敗: {e}")
             self.is_connected = False
             return False
 
@@ -74,30 +74,26 @@ class SerialCommunicator:
                 continue # 繼續下一輪迴圈
                 
             try:
-                if self.ser and self.ser.is_open and self.ser.in_waiting > 0: # 如果序列埠可用且有數據
-                    response = self.ser.readline().decode('utf-8', 'ignore').strip() # 讀取一行數據
-                    if response: # 如果讀到內容
-                        self.message_log.append(response) # 加入日誌
-            except serial.SerialException: # 捕捉序列埠錯誤
-                self.message_log.append("[ERROR] Serial port disconnected.") # 在日誌中記錄錯誤
-                self.is_connected = False # 更新連接狀態
-                break # 退出迴圈
+                if self.ser and self.ser.is_open and self.ser.in_waiting > 0:
+                    response = self.ser.readline().decode('utf-8', 'ignore').strip()
+                    if response:
+                        log.info(f"[Teensy]: {response}")
+            except serial.SerialException:
+                log.error("[ERROR] Serial port disconnected.")
+                self.is_connected = False
+                break
             time.sleep(0.01) # 短暫休眠
 
     def send_command(self, command: str):
-        """向序列埠發送一個字串指令，僅在 SERIAL_MODE 下有效。"""
-        if self.is_connected and command and not self.is_managed_by_hardware_controller: # 檢查發送條件
+        """向序列埠發送一個字串指令。"""
+        if self.is_connected and command and not self.is_managed_by_hardware_controller:
             try:
-                command_to_send = command + '\n' # 加上換行符
-                self.ser.write(command_to_send.encode('utf-8')) # 發送指令
-                self.message_log.append(f"> {command}") # 將發送的指令也加入日誌
-            except serial.SerialException as e: # 捕捉發送錯誤
-                 self.message_log.append(f"[ERROR] Send failed: {e}") # 在日誌中記錄錯誤
-                 self.is_connected = False # 更新連接狀態
+                command_to_send = command + '\n'
+                self.ser.write(command_to_send.encode('utf-8'))
+            except serial.SerialException as e:
+                log.error(f"[ERROR] Send failed: {e}")
+                self.is_connected = False
 
-    def get_latest_messages(self) -> list:
-        """獲取日誌中的所有訊息，用於UI顯示。"""
-        return list(self.message_log) # 返回日誌列表
 
     def close(self):
         """安全地關閉序列埠和讀取執行緒。"""
@@ -108,5 +104,5 @@ class SerialCommunicator:
             self.read_thread.join(timeout=1) # 等待執行緒結束
         if self.ser and self.ser.is_open: # 如果序列埠已開啟
             self.ser.close() # 關閉序列埠
-            print(f"序列埠 {self.port_name} 已安全關閉。")
+            log.info(f"序列埠 {self.port_name} 已安全關閉。")
         self.is_connected = False # 更新連接狀態

--- a/simulation.py
+++ b/simulation.py
@@ -3,8 +3,7 @@ import mujoco
 import glfw
 import sys
 import numpy as np
-from typing import TYPE_CHECKING
-import os
+from typing import TYPE_CHECKING, Optional
 
 from config import AppConfig
 from state import SimulationState, TuningParams
@@ -16,10 +15,13 @@ if TYPE_CHECKING:
 class Simulation:
     """
     封裝 MuJoCo 模擬、GLFW 視窗和渲染邏輯。
+    【核心變更】將 GLFW 初始化延遲至模擬執行緒。
     """
     def __init__(self, config: AppConfig):
-        """初始化 MuJoCo 模型、資料、GLFW 視窗以及滑鼠控制相關狀態。"""
+        """僅初始化 MuJoCo 模型與資料，不建立視窗。"""
         self.config = config
+        self.window: Optional[glfw._GLFWwindow] = None
+        self.keyboard_handler: Optional[KeyboardInputHandler] = None
         
         try:
             with open(config.mujoco_model_file, 'r', encoding='utf-8') as f:
@@ -50,8 +52,13 @@ class Simulation:
             self.default_pose = np.zeros(config.num_motors)
             print("⚠️ 警告: 在 XML 中未找到名為 'home' 的 keyframe，將使用零作為預設姿態。")
 
-        if not glfw.init(): sys.exit("❌ 錯誤: GLFW 初始化失敗。")
-        self.window = glfw.create_window(1200, 900, "MuJoCo 模擬器 (含滑鼠控制)", None, None)
+        # 視窗與渲染上下文將在模擬執行緒中初始化
+
+    def initialize_window_and_context(self):
+        """在當前執行緒中初始化 GLFW 與渲染上下文。"""
+        if not glfw.init():
+            sys.exit("❌ 錯誤: GLFW 初始化失敗。")
+        self.window = glfw.create_window(1200, 900, "MuJoCo 3D 渲染視窗", None, None)
         if not self.window:
             glfw.terminate()
             sys.exit("❌ 錯誤: GLFW 視窗建立失敗。")
@@ -65,19 +72,22 @@ class Simulation:
 
         self.cam = mujoco.MjvCamera()
         self.opt = mujoco.MjvOption()
+        self.overlay = DebugOverlay()
         mujoco.mjv_defaultCamera(self.cam)
         mujoco.mjv_defaultOption(self.opt)
         self.cam.distance, self.cam.elevation, self.cam.azimuth = 2.5, -20, 90
-        
+
         self.scene = mujoco.MjvScene(self.model, maxgeom=10000)
         self.context = mujoco.MjrContext(self.model, mujoco.mjtFontScale.mjFONTSCALE_100)
-        self.overlay = DebugOverlay()
-        
+
         glfw.set_cursor_pos_callback(self.window, self._mouse_move_callback)
         glfw.set_mouse_button_callback(self.window, self._mouse_button_callback)
         glfw.set_scroll_callback(self.window, self._scroll_callback)
 
-        print("✅ MuJoCo 模擬環境與視窗初始化完成 (含滑鼠控制)。")
+        if self.keyboard_handler:
+            self.keyboard_handler.register_callbacks(self.window)
+
+        print("✅ GLFW 視窗與渲染上下文在模擬執行緒中初始化完成。")
 
     def _mouse_button_callback(self, window, button, action, mods):
         if button == glfw.MOUSE_BUTTON_LEFT:
@@ -109,7 +119,8 @@ class Simulation:
         mujoco.mjv_moveCamera(self.model, mujoco.mjtMouse.mjMOUSE_ZOOM, 0, -0.05 * yoffset, self.scene, self.cam)
 
     def register_callbacks(self, keyboard_handler: "KeyboardInputHandler"):
-        keyboard_handler.register_callbacks(self.window)
+        """在窗口初始化後再註冊鍵盤事件。"""
+        self.keyboard_handler = keyboard_handler
 
     def reset(self):
         mujoco.mj_resetData(self.model, self.data)
@@ -117,6 +128,8 @@ class Simulation:
         print("✅ MuJoCo 模擬已重置。")
 
     def should_close(self) -> bool:
+        if not self.window:
+            return True
         return glfw.window_should_close(self.window)
         
     def apply_position_control(self, target_pos: np.ndarray, params: TuningParams):
@@ -132,6 +145,8 @@ class Simulation:
             mujoco.mj_step(self.model, self.data)
 
     def render(self, state: SimulationState):
+        if not self.window:
+            return
         viewport = mujoco.MjrRect(0, 0, *glfw.get_framebuffer_size(self.window))
         self.overlay.render(viewport, self.context, state, self)
         glfw.swap_buffers(self.window)
@@ -152,4 +167,6 @@ class Simulation:
             pass
         
     def close(self):
-        glfw.terminate()
+        if self.window:
+            glfw.terminate()
+            self.window = None

--- a/simulation_controller.py
+++ b/simulation_controller.py
@@ -1,0 +1,166 @@
+"""Run MuJoCo simulation in a background thread."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import mujoco
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - type hints
+    from state import SimulationState
+
+
+class SimulationController:
+    """Handle stepping and rendering of the simulation in its own thread."""
+
+    def __init__(self, state: SimulationState) -> None:
+        self.state = state
+        self.sim = state.sim
+        self.config = state.config
+
+        self.policy_manager = state.policy_manager_ref
+        self.terrain_manager = state.terrain_manager_ref
+        self.floating_controller = state.floating_controller_ref
+        self.xbox_handler = state.xbox_handler_ref
+
+        self._running = threading.Event()
+        self._running.set()
+
+        self._initialize_simulation()
+
+    # ------------------------------------------------------------------
+    def _initialize_simulation(self) -> None:
+        if self.terrain_manager.is_functional:
+            self.terrain_manager.initial_generate()
+        self.hard_reset()
+        print("\n--- Simulation Started (SPACE: Pause, N: Step) ---")
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        while self._running.is_set():
+            with self.state.lock:
+                single_step = self.state.single_step_mode
+                execute_one = self.state.execute_one_step
+                current_input_mode = self.state.input_mode
+                hard_reset_req = self.state.hard_reset_requested
+                soft_reset_req = self.state.soft_reset_requested
+                current_control_mode = self.state.control_mode
+
+            if single_step and not execute_one:
+                self.sim.render_from_thread(self.state)
+                time.sleep(0.01)
+                continue
+            if execute_one:
+                with self.state.lock:
+                    self.state.execute_one_step = False
+
+            if hard_reset_req:
+                self.hard_reset()
+            if soft_reset_req:
+                self.soft_reset()
+
+            if current_input_mode == "GAMEPAD":
+                self.xbox_handler.update_state()
+
+            if current_control_mode in ["HARDWARE_MODE", "SERIAL_MODE"]:
+                pass
+            else:
+                self._simulation_step()
+
+            with self.state.lock:
+                self.state.latest_pos = self.sim.data.body('torso').xpos.copy()
+                self.state.latest_quat = self.sim.data.body('torso').xquat.copy()
+
+            if self.terrain_manager.is_functional:
+                self.terrain_manager.update(self.state.latest_pos, self.state.terrain_mode)
+
+            self.sim.render_from_thread(self.state)
+
+        print("simulation thread stopped")
+
+    # ------------------------------------------------------------------
+    def _simulation_step(self) -> None:
+        with self.state.lock:
+            command = self.state.command.copy()
+            control_mode = self.state.control_mode
+            tuning_params = self.state.tuning_params
+
+        onnx_input, action_final = self.policy_manager.get_action(command)
+
+        if control_mode == "MANUAL_CTRL":
+            with self.state.lock:
+                final_ctrl = self.state.manual_final_ctrl.copy()
+        elif control_mode == "JOINT_TEST":
+            with self.state.lock:
+                final_ctrl = self.sim.default_pose + self.state.joint_test_offsets
+        else:
+            final_ctrl = self.sim.default_pose + action_final * tuning_params.action_scale
+
+        self.sim.apply_position_control(final_ctrl, tuning_params)
+
+        with self.state.lock:
+            self.state.latest_onnx_input = onnx_input.flatten()
+            self.state.latest_action_raw = action_final
+            self.state.latest_final_ctrl = final_ctrl
+
+        target_time = self.sim.data.time + self.config.control_dt
+        while self.sim.data.time < target_time:
+            if not self._running.is_set():
+                break
+            mujoco.mj_step(self.sim.model, self.sim.data)
+
+    # ------------------------------------------------------------------
+    def stop(self) -> None:
+        self._running.clear()
+
+    # ------------------------------------------------------------------
+    def hard_reset(self) -> None:
+        print("\n--- 正在執行機器人硬重置 ---")
+        with self.state.lock:
+            if self.state.control_mode == "HARDWARE_MODE":
+                return
+
+            mujoco.mj_resetData(self.sim.model, self.sim.data)
+            self.sim.data.qpos[0], self.sim.data.qpos[1] = 0, 0
+            start_ground_z = self.terrain_manager.get_height_at(0, 0)
+            robot_height_offset = 0.3
+            self.sim.data.qpos[2] = start_ground_z + robot_height_offset
+            self.sim.data.qpos[3:7] = np.array([1., 0, 0, 0])
+            self.sim.data.qpos[7:] = self.sim.default_pose
+            self.sim.data.qvel[:] = 0
+            self.sim.data.ctrl[:] = self.sim.default_pose
+            for _ in range(10):
+                mujoco.mj_step(self.sim.model, self.sim.data)
+
+            self.policy_manager.reset()
+            if self.state.control_mode == "FLOATING":
+                self.state.set_control_mode("WALKING")
+            self.state.reset_control_state(self.sim.data.time)
+            self.state.clear_command()
+            self.state.joint_test_offsets.fill(0.0)
+            self.state.manual_final_ctrl.fill(0.0)
+            self.state.manual_mode_is_floating = False
+            self.state.hard_reset_requested = False
+            mujoco.mj_forward(self.sim.model, self.sim.data)
+
+    def soft_reset(self) -> None:
+        print("\n--- 正在執行空中姿態重置 ---")
+        with self.state.lock:
+            if self.state.control_mode == "HARDWARE_MODE":
+                return
+
+            self.sim.data.qpos[3:7] = np.array([1., 0, 0, 0])
+            self.sim.data.qpos[7:] = self.sim.default_pose
+            self.sim.data.qvel[:] = 0
+
+            self.policy_manager.reset()
+            self.state.clear_command()
+            self.state.joint_test_offsets.fill(0.0)
+            self.state.manual_final_ctrl.fill(0.0)
+            self.state.manual_mode_is_floating = False
+            mujoco.mj_forward(self.sim.model, self.sim.data)
+            self.state.soft_reset_requested = False
+

--- a/simulation_controller.py
+++ b/simulation_controller.py
@@ -29,10 +29,10 @@ class SimulationController:
         self._running = threading.Event()
         self._running.set()
 
-        self._initialize_simulation()
+        # 初始化將在執行緒啟動後進行
 
     # ------------------------------------------------------------------
-    def _initialize_simulation(self) -> None:
+    def _initialize_simulation_state(self) -> None:
         if self.terrain_manager.is_functional:
             self.terrain_manager.initial_generate()
         self.hard_reset()
@@ -40,7 +40,17 @@ class SimulationController:
 
     # ------------------------------------------------------------------
     def run(self) -> None:
+        # 執行緒啟動後的初始化
+        self.sim.initialize_window_and_context()
+        self._initialize_simulation_state()
+
         while self._running.is_set():
+            if self.sim.should_close():
+                self._running.clear()
+                from nicegui import app
+                app.shutdown()
+                continue
+
             with self.state.lock:
                 single_step = self.state.single_step_mode
                 execute_one = self.state.execute_one_step

--- a/simulation_controller.py
+++ b/simulation_controller.py
@@ -42,6 +42,8 @@ class SimulationController:
     def run(self) -> None:
         # 執行緒啟動後的初始化
         self.sim.initialize_window_and_context()
+        # 在模擬執行緒中初始化 Pygame，確保事件處理在同一執行緒
+        self.xbox_handler.controller.initialize()
         self._initialize_simulation_state()
 
         while self._running.is_set():
@@ -72,8 +74,8 @@ class SimulationController:
             if soft_reset_req:
                 self.soft_reset()
 
-            if current_input_mode == "GAMEPAD":
-                self.xbox_handler.update_state()
+            # 持續更新搖桿事件，避免事件堆積並能即時偵測連線狀態
+            self.xbox_handler.update_state()
 
             if current_control_mode in ["HARDWARE_MODE", "SERIAL_MODE"]:
                 pass

--- a/state.py
+++ b/state.py
@@ -54,9 +54,6 @@ class SimulationState:
     num_display_pages: int = 2 # 除錯資訊的總頁數
 
     # --- 【序列埠控制台模式相關狀態】 ---
-    serial_command_buffer: str = "" # 用於儲存使用者在序列埠模式下正在輸入的文字
-    serial_command_to_send: str = "" # 當使用者按下Enter後，指令會被移到這裡，等待main.py發送
-    serial_latest_messages: list = field(default_factory=list) # 儲存從硬體收到的訊息日誌，用於顯示
 
     joint_test_index: int = 0 # 在關節測試模式下，當前選中的關節索引
     joint_test_offsets: np.ndarray = field(default_factory=lambda: np.zeros(12)) # 儲存各關節在測試模式下的偏移量

--- a/state.py
+++ b/state.py
@@ -103,12 +103,13 @@ class SimulationState:
         self.command.fill(0.0) # 將指令向量全部設為 0
         print("運動指令已清除。")
 
-    def toggle_input_mode(self, new_mode: str):
-        """切換輸入模式 (鍵盤/搖桿)。"""
-        with self.lock:  # 【執行緒安全】確保狀態變更原子化
-            if self.input_mode != new_mode:  # 如果新模式與當前模式不同
-                self.input_mode = new_mode  # 更新模式
-                self.clear_command()  # 清除舊的指令，避免殘留
+    def toggle_input_mode(self, new_mode: str, clear_cmd: bool = True):
+        """切換輸入模式，可選擇是否清除現有指令。"""
+        with self.lock:
+            if self.input_mode != new_mode:
+                self.input_mode = new_mode
+                if clear_cmd:
+                    self.clear_command()
                 print(f"輸入模式已切換至: {self.input_mode}")
             
     def set_control_mode(self, new_mode: str):

--- a/state.py
+++ b/state.py
@@ -108,59 +108,66 @@ class SimulationState:
 
     def toggle_input_mode(self, new_mode: str):
         """切換輸入模式 (鍵盤/搖桿)。"""
-        if self.input_mode != new_mode: # 如果新模式與當前模式不同
-            self.input_mode = new_mode # 更新模式
-            self.clear_command() # 清除舊的指令，避免殘留
-            print(f"輸入模式已切換至: {self.input_mode}")
+        with self.lock:  # 【執行緒安全】確保狀態變更原子化
+            if self.input_mode != new_mode:  # 如果新模式與當前模式不同
+                self.input_mode = new_mode  # 更新模式
+                self.clear_command()  # 清除舊的指令，避免殘留
+                print(f"輸入模式已切換至: {self.input_mode}")
             
     def set_control_mode(self, new_mode: str):
         """【智慧模式切換】切換主控制模式，並能記住進入 SERIAL_MODE 前的狀態。"""
-        if self.control_mode == new_mode: return # 如果模式未改變，則不執行任何操作
+        with self.lock:  # 【執行緒安全】確保模式切換時沒有競爭條件
+            if self.control_mode == new_mode:
+                return  # 如果模式未改變，則不執行任何操作
 
-        old_mode = self.control_mode # 儲存舊模式以進行清理
-        
-        # 【新邏輯】如果準備進入 SERIAL_MODE，先記下當前的模式，以便之後可以返回
-        if new_mode == "SERIAL_MODE":
-            self.previous_control_mode = old_mode # 記錄切換前的模式
-        
-        # --- 處理離開舊模式時的清理工作 ---
-        if old_mode == "FLOATING":
-            if self.floating_controller_ref: self.floating_controller_ref.disable() # 禁用懸浮約束
-        elif old_mode == "MANUAL_CTRL" and self.manual_mode_is_floating:
-             if self.floating_controller_ref: self.floating_controller_ref.disable() # 禁用懸浮約束
-             self.manual_mode_is_floating = False # 重置手動懸浮旗標
-        elif old_mode == "HARDWARE_MODE":
-            # 只有當我們要切換到一個非硬體也非序列埠的模式時，才停止硬體控制器
-            if new_mode not in ["SERIAL_MODE", "JOINT_TEST"]:
-                if self.hardware_controller_ref: self.hardware_controller_ref.stop() # 停止硬體控制器執行緒
-                self.hardware_is_connected = False # 更新連接狀態
-                self.hardware_ai_is_active = False # 更新 AI 狀態
-            
-        self.control_mode = new_mode # 正式更新到新模式
-        print(f"控制模式已切換至: {self.control_mode}")
+            old_mode = self.control_mode  # 儲存舊模式以進行清理
 
-        # --- 處理進入新模式時的初始化工作 ---
-        if new_mode == "FLOATING":
-            if self.floating_controller_ref: self.floating_controller_ref.enable(self.latest_pos) # 啟用懸浮
-        elif new_mode == "JOINT_TEST":
-            self.joint_test_offsets.fill(0.0) # 清空關節偏移量
-        elif new_mode == "MANUAL_CTRL":
-            self.manual_final_ctrl[:] = self.latest_final_ctrl # 將當前控制角度作為手動控制的初始值
-        elif new_mode == "HARDWARE_MODE":
-             if self.hardware_controller_ref and not self.hardware_controller_ref.is_running: # 如果硬體控制器存在且未運行
-                 if self.hardware_controller_ref.connect_and_start(): # 嘗試啟動
-                     self.hardware_is_connected = True
-                 else:
-                     print("❌ 硬體連接失敗，自動返回 WALKING 模式。")
-                     self.control_mode = "WALKING" # 如果啟動失敗，自動退回安全模式
-                     print(f"控制模式已自動切換至: {self.control_mode}")
+            # 【新邏輯】如果準備進入 SERIAL_MODE，先記下當前的模式，以便之後可以返回
+            if new_mode == "SERIAL_MODE":
+                self.previous_control_mode = old_mode  # 記錄切換前的模式
 
-        # --- 處理從手動模式切換回 AI 模式時的重置邏輯 ---
-        is_entering_ai_mode = new_mode in ["WALKING", "FLOATING"] # 判斷是否進入 AI 模式
-        is_leaving_manual_mode = old_mode in ["JOINT_TEST", "MANUAL_CTRL", "SERIAL_MODE"] # 判斷是否離開手動/除錯模式
-        
-        if is_entering_ai_mode and is_leaving_manual_mode:
-            print("從手動/序列埠模式返回，正在重置 AI 狀態以確保平滑過渡...")
-            if self.policy_manager_ref:
-                self.policy_manager_ref.reset() # 重置 AI 策略的歷史狀態
-            self.clear_command() # 清除使用者指令
+            # --- 處理離開舊模式時的清理工作 ---
+            if old_mode == "FLOATING":
+                if self.floating_controller_ref:
+                    self.floating_controller_ref.disable()  # 禁用懸浮約束
+            elif old_mode == "MANUAL_CTRL" and self.manual_mode_is_floating:
+                if self.floating_controller_ref:
+                    self.floating_controller_ref.disable()  # 禁用懸浮約束
+                self.manual_mode_is_floating = False  # 重置手動懸浮旗標
+            elif old_mode == "HARDWARE_MODE":
+                # 只有當我們要切換到一個非硬體也非序列埠的模式時，才停止硬體控制器
+                if new_mode not in ["SERIAL_MODE", "JOINT_TEST"]:
+                    if self.hardware_controller_ref:
+                        self.hardware_controller_ref.stop()  # 停止硬體控制器執行緒
+                    self.hardware_is_connected = False
+                    self.hardware_ai_is_active = False
+
+            self.control_mode = new_mode  # 正式更新到新模式
+            print(f"控制模式已切換至: {self.control_mode}")
+
+            # --- 處理進入新模式時的初始化工作 ---
+            if new_mode == "FLOATING":
+                if self.floating_controller_ref:
+                    self.floating_controller_ref.enable(self.latest_pos)  # 啟用懸浮
+            elif new_mode == "JOINT_TEST":
+                self.joint_test_offsets.fill(0.0)
+            elif new_mode == "MANUAL_CTRL":
+                self.manual_final_ctrl[:] = self.latest_final_ctrl
+            elif new_mode == "HARDWARE_MODE":
+                if self.hardware_controller_ref and not self.hardware_controller_ref.is_running:
+                    if self.hardware_controller_ref.connect_and_start():
+                        self.hardware_is_connected = True
+                    else:
+                        print("❌ 硬體連接失敗，自動返回 WALKING 模式。")
+                        self.control_mode = "WALKING"
+                        print(f"控制模式已自動切換至: {self.control_mode}")
+
+            # --- 處理從手動模式切換回 AI 模式時的重置邏輯 ---
+            is_entering_ai_mode = new_mode in ["WALKING", "FLOATING"]
+            is_leaving_manual_mode = old_mode in ["JOINT_TEST", "MANUAL_CTRL", "SERIAL_MODE"]
+
+            if is_entering_ai_mode and is_leaving_manual_mode:
+                print("從手動/序列埠模式返回，正在重置 AI 狀態以確保平滑過渡...")
+                if self.policy_manager_ref:
+                    self.policy_manager_ref.reset()
+                self.clear_command()

--- a/ui_controller.py
+++ b/ui_controller.py
@@ -121,7 +121,8 @@ class UIController:
     def _create_log_panel(self) -> None:
         with ui.card().classes('w-full'):
             ui.label('日誌輸出 (Log Output)').classes('text-lg')
-            self.log_area = ui.textarea(label='Log').props('readonly outlined').style('width: 100%;').lines(10)
+            # "rows=10" 用於設定顯示高度，取代錯誤的 .lines()
+            self.log_area = ui.textarea(label='Log').props('readonly outlined rows=10').style('width: 100%;')
 
     # ------------------------------------------------------------------
     def update_ui_elements(self) -> None:

--- a/ui_controller.py
+++ b/ui_controller.py
@@ -1,0 +1,211 @@
+"""NiceGUI based control panel."""
+
+from typing import TYPE_CHECKING
+
+from nicegui import ui
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - type hints
+    from state import SimulationState
+
+
+class UIController:
+    """Encapsulate all NiceGUI layout and callbacks."""
+
+    def __init__(self, state: 'SimulationState') -> None:
+        self.state = state
+        self.policy_manager = state.policy_manager_ref
+        self.hardware_controller = state.hardware_controller_ref
+        self.serial_comm = state.serial_communicator_ref
+        self.xbox_handler = state.xbox_handler_ref
+
+        self.status_labels: dict[str, ui.label] = {}
+        self.param_sliders: dict[str, ui.slider] = {}
+        self.onnx_input_labels: dict[str, ui.label] = {}
+        self.log_area: ui.textarea | None = None
+
+        self._setup_ui()
+
+    def _setup_ui(self) -> None:
+        ui.dark_mode().enable()
+        with ui.header(elevated=True).style('background-color: #3874c8'):
+            ui.label('Pupper 機器人控制台').classes('text-lg')
+
+        with ui.row().classes('w-full no-wrap'):
+            with ui.column().classes('w-1/3'):
+                self._create_control_panel()
+                self._create_tuning_panel()
+            with ui.column().classes('w-2/3'):
+                self._create_status_display()
+                self._create_onnx_display()
+                self._create_log_panel()
+
+        ui.timer(0.1, self.update_ui_elements)
+
+    def _create_control_panel(self) -> None:
+        with ui.card():
+            ui.label('模式控制 (Control Mode)').classes('text-lg')
+            with ui.row():
+                ui.button('走路 (Walking)', on_click=lambda: self.state.set_control_mode("WALKING"))
+                ui.button('懸浮 (Floating)', on_click=lambda: self.state.set_control_mode("FLOATING"))
+                ui.button('硬體 (Hardware)', on_click=lambda: self.state.set_control_mode("HARDWARE_MODE"))
+            with ui.row():
+                ui.button('關節測試 (Joint Test)', on_click=lambda: self.state.set_control_mode("JOINT_TEST"))
+                ui.button('手動控制 (Manual Ctrl)', on_click=lambda: self.state.set_control_mode("MANUAL_CTRL"))
+
+            ui.separator()
+            ui.label('硬體 AI 控制').classes('text-lg')
+            ui.button('啟用/停用 AI (K)', on_click=self._toggle_hardware_ai).bind_enabled_from(
+                self.state, 'control_mode', lambda m: m == "HARDWARE_MODE")
+
+            ui.separator()
+            ui.label('設備與重置').classes('text-lg')
+            with ui.row():
+                ui.button('連接序列埠 (U)', on_click=self._connect_serial)
+                ui.button('連接搖桿 (J)', on_click=self._connect_gamepad)
+            with ui.row():
+                ui.button('軟重置 (X)', on_click=lambda: self.set_request_flag('soft_reset_requested'))
+                ui.button('硬重置 (R)', on_click=lambda: self.set_request_flag('hard_reset_requested'))
+
+    def _create_tuning_panel(self) -> None:
+        with ui.card().classes('w-full'):
+            ui.label('參數調整 (Tuning)').classes('text-lg')
+            params = self.state.tuning_params
+            p_keys = {'kp': (0, 50), 'kd': (0, 5), 'action_scale': (0, 2), 'bias': (-20, 20)}
+            for key, (mn, mx) in p_keys.items():
+                with ui.row().classes('w-full items-center'):
+                    ui.label(key.upper()).classes('w-20')
+                    ui.slider(min=mn, max=mx, step=0.01, value=getattr(params, key)).bind_value(params, key).classes('w-48')
+                    ui.label().bind_text_from(params, key, lambda v: f'{v:.2f}')
+
+            ui.separator()
+            ui.label('策略選擇 (Policy)').classes('text-lg')
+            self.status_labels['policy_selector'] = ui.select(
+                options=self.state.available_policies,
+                label='Active Policy',
+                value=self.policy_manager.primary_policy_name,
+                on_change=lambda e: self.policy_manager.select_target_policy(e.value)
+            ).classes('w-full')
+
+    def _create_status_display(self) -> None:
+        with ui.card():
+            ui.label('即時狀態 (Real-time Status)').classes('text-lg')
+            with ui.grid(columns=3):
+                self.status_labels['mode'] = ui.label('模式: WALKING')
+                self.status_labels['input_mode'] = ui.label('輸入: KEYBOARD')
+                self.status_labels['sim_time'] = ui.label('時間: 0.00s')
+                self.status_labels['serial_status'] = ui.label('序列埠: Disconnected')
+                self.status_labels['gamepad_status'] = ui.label('搖桿: Disconnected')
+                self.status_labels['hardware_ai'] = ui.label('硬體AI: N/A')
+                self.status_labels['policy_status'] = ui.label(f'策略: {self.policy_manager.primary_policy_name}')
+
+            ui.separator()
+            ui.label('運動指令 (Command)').classes('font-bold')
+            self.status_labels['command'] = ui.label('vy: 0.00, vx: 0.00, wz: 0.00')
+
+            ui.label('機器人狀態 (Robot State)').classes('font-bold')
+            self.status_labels['robot_pos'] = ui.label('位置: [0.0, 0.0, 0.0]')
+            self.status_labels['robot_vel'] = ui.label('速度: [0.0, 0.0, 0.0]')
+
+    def _create_onnx_display(self) -> None:
+        with ui.card().classes('w-full'):
+            ui.label('ONNX 觀察向量 (Observation Vector)').classes('text-lg')
+            with ui.grid(columns=2):
+                obs_components = [
+                    'linear_velocity', 'angular_velocity', 'gravity_vector', 'commands',
+                    'accelerometer', 'joint_positions', 'joint_velocities', 'last_action'
+                ]
+                for comp in obs_components:
+                    self.onnx_input_labels[comp] = ui.label(f'{comp}: N/A')
+
+    def _create_log_panel(self) -> None:
+        with ui.card().classes('w-full'):
+            ui.label('日誌輸出 (Log Output)').classes('text-lg')
+            self.log_area = ui.textarea(label='Log').props('readonly outlined').style('width: 100%;').lines(10)
+
+    # ------------------------------------------------------------------
+    def update_ui_elements(self) -> None:
+        with self.state.lock:
+            self.status_labels['mode'].text = f"模式: {self.state.control_mode}"
+            self.status_labels['input_mode'].text = f"輸入: {self.state.input_mode}"
+            if self.state.sim:
+                self.status_labels['sim_time'].text = f"時間: {self.state.sim.data.time:.2f}s"
+            self.status_labels['serial_status'].text = (
+                '序列埠: Connected' if self.state.serial_is_connected else '序列埠: Disconnected'
+            )
+            self.status_labels['gamepad_status'].text = (
+                '搖桿: Connected' if self.state.gamepad_is_connected else '搖桿: Disconnected'
+            )
+            if self.state.control_mode == 'HARDWARE_MODE':
+                self.status_labels['hardware_ai'].text = '硬體AI: Active' if self.state.hardware_ai_is_active else '硬體AI: Disabled'
+            else:
+                self.status_labels['hardware_ai'].text = '硬體AI: N/A'
+
+            cmd = self.state.command
+            self.status_labels['command'].text = f"vy: {cmd[0]:.2f}, vx: {cmd[1]:.2f}, wz: {cmd[2]:.2f}"
+
+            pos = self.state.latest_pos
+            self.status_labels['robot_pos'].text = f"位置: [{pos[0]:.2f}, {pos[1]:.2f}, {pos[2]:.2f}]"
+
+            pm = self.policy_manager
+            if pm.is_transitioning:
+                alpha_percent = pm.transition_alpha * 100
+                policy_text = f"策略: Blending {pm.source_policy_name} -> {pm.target_policy_name} ({alpha_percent:.0f}%)"
+            else:
+                policy_text = f"策略: {pm.primary_policy_name}"
+            self.status_labels['policy_status'].text = policy_text
+            self.status_labels['policy_selector'].value = pm.primary_policy_name
+
+            self._update_onnx_labels()
+
+            if self.state.control_mode == 'SERIAL_MODE':
+                self.log_area.value = "\n".join(self.state.serial_latest_messages)
+            else:
+                self.log_area.value = self.state.hardware_status_text if self.state.control_mode == 'HARDWARE_MODE' else ''
+
+    def _update_onnx_labels(self) -> None:
+        if self.state.latest_onnx_input.size == 0 or not self.policy_manager.get_active_recipe():
+            return
+
+        recipe = self.policy_manager.get_active_recipe()
+        obs_vec = self.state.latest_onnx_input
+        current_idx = 0
+        component_dims = self.policy_manager.obs_builder.component_dims
+
+        for comp_name in recipe:
+            dim = component_dims.get(comp_name, 0)
+            if dim > 0 and comp_name in self.onnx_input_labels:
+                end_idx = current_idx + dim
+                if end_idx <= len(obs_vec):
+                    value_slice = obs_vec[current_idx:end_idx]
+                    vec_str = np.array2string(value_slice, precision=2, suppress_small=True, max_line_width=30)
+                    self.onnx_input_labels[comp_name].text = f'{comp_name}: {vec_str}'
+                current_idx = end_idx
+
+    # ------------------------------------------------------------------
+    def _toggle_hardware_ai(self) -> None:
+        if self.hardware_controller and self.state.control_mode == 'HARDWARE_MODE':
+            if self.state.hardware_ai_is_active:
+                self.hardware_controller.disable_ai()
+            else:
+                self.hardware_controller.enable_ai()
+
+    def set_request_flag(self, flag_name: str) -> None:
+        with self.state.lock:
+            setattr(self.state, flag_name, True)
+
+    def _connect_serial(self) -> None:
+        if self.serial_comm:
+            connected = self.serial_comm.scan_and_connect()
+            with self.state.lock:
+                self.state.serial_is_connected = connected
+
+    def _connect_gamepad(self) -> None:
+        if self.xbox_handler:
+            connected = self.xbox_handler.scan_and_connect()
+            with self.state.lock:
+                self.state.gamepad_is_connected = connected
+
+    def run(self) -> None:
+        ui.run(title="Pupper Robot Console", port=8080)
+

--- a/ui_controller.py
+++ b/ui_controller.py
@@ -88,10 +88,14 @@ class UIController:
     def _create_joystick_panel(self):
         with ui.card().classes('w-full'):
             ui.label('手動駕駛 (Manual Driving)').classes('text-lg')
-            ui.joystick(color='blue', size=100,
-                        on_move=lambda e: self._update_command_from_joystick(e),
-                        on_end=lambda e: self.state.clear_command()).props('throttle')
-            ui.button('清除命令', on_click=self.state.clear_command).props('outline')
+            ui.joystick(
+                color='blue',
+                size=100,
+                on_move=lambda e: self._update_command_from_joystick(e),
+                # 當搖桿釋放時呼叫自定函式，清除指令並恢復輸入模式
+                on_end=lambda e: self._on_joystick_end()
+            ).props('throttle')
+            ui.button('清除命令 (Clear Command)', on_click=self.state.clear_command).props('outline')
 
     def _create_status_display(self):
         with ui.card():
@@ -199,11 +203,21 @@ class UIController:
         x_val = -event.args.y / 50.0
         y_val = event.args.x / 50.0
         with self.state.lock:
-            if self.state.input_mode != "GAMEPAD":
-                self.state.input_mode = "GAMEPAD"
+            # 使用虛擬搖桿時，切換到專屬的 VJOY 模式，避免與實體搖桿衝突
+            if self.state.input_mode != "VJOY":
+                self.state.input_mode = "VJOY"
+                log.info("輸入模式已切換至 VJOY (虛擬搖桿)")
             self.state.command[0] = y_val * self.state.config.gamepad_sensitivity['vy']
             self.state.command[1] = x_val * self.state.config.gamepad_sensitivity['vx']
             self.state.command[2] = 0.0
+
+    def _on_joystick_end(self):
+        """虛擬搖桿釋放時的回呼函式。"""
+        with self.state.lock:
+            if self.state.input_mode == "VJOY":
+                self.state.clear_command()
+                self.state.input_mode = "KEYBOARD"
+                log.info("虛擬搖桿已釋放，輸入模式切回 KEYBOARD")
 
     def _send_serial_command(self):
         command_text = self.serial_command_buffer.value

--- a/ui_controller.py
+++ b/ui_controller.py
@@ -93,8 +93,7 @@ class UIController:
                 color='blue',
                 size=100,
                 on_move=lambda e: self._update_command_from_joystick(e),
-                # 當搖桿釋放時呼叫自定函式，清除指令並恢復輸入模式
-                on_end=lambda e: self._on_joystick_end()
+                on_end=self._on_joystick_end  # 直接傳遞方法
             ).props('throttle')
             ui.button('清除命令 (Clear Command)', on_click=self.state.clear_command).props('outline')
 
@@ -252,22 +251,20 @@ class UIController:
     def _update_command_from_joystick(self, event):
         x_val = -event.args.y / 50.0
         y_val = event.args.x / 50.0
+        # 切換到虛擬搖桿輸入模式，但保留當前指令
+        self.state.toggle_input_mode("VJOY", clear_cmd=False)
         with self.state.lock:
-            # 使用虛擬搖桿時，切換到專屬的 VJOY 模式，避免與實體搖桿衝突
-            if self.state.input_mode != "VJOY":
-                self.state.input_mode = "VJOY"
-                log.info("輸入模式已切換至 VJOY (虛擬搖桿)")
             self.state.command[0] = y_val * self.state.config.gamepad_sensitivity['vy']
             self.state.command[1] = x_val * self.state.config.gamepad_sensitivity['vx']
             self.state.command[2] = 0.0
 
-    def _on_joystick_end(self):
+    def _on_joystick_end(self, event):
         """虛擬搖桿釋放時的回呼函式。"""
         with self.state.lock:
             if self.state.input_mode == "VJOY":
                 self.state.clear_command()
-                self.state.input_mode = "KEYBOARD"
-                log.info("虛擬搖桿已釋放，輸入模式切回 KEYBOARD")
+        # 切回鍵盤輸入模式，但不要再次清除指令
+        self.state.toggle_input_mode("KEYBOARD", clear_cmd=False)
 
     def _send_serial_command(self):
         command_text = self.serial_command_buffer.value

--- a/ui_controller.py
+++ b/ui_controller.py
@@ -165,7 +165,8 @@ class UIController:
         recipe = self.policy_manager.get_active_recipe()
         obs_vec = self.state.latest_onnx_input
         current_idx = 0
-        component_dims = self.state.policy_manager.obs_builder.component_dims
+        # 從已註冊的 policy_manager 取得各觀察元件的維度
+        component_dims = self.policy_manager.obs_builder.component_dims
         for comp_name in recipe:
             dim = component_dims.get(comp_name, 0)
             if dim > 0 and comp_name in self.onnx_input_labels:

--- a/ui_controller.py
+++ b/ui_controller.py
@@ -34,6 +34,7 @@ class UIController:
                 self._create_control_panel()
                 self._create_tuning_panel()
                 self._create_joystick_panel()
+                self._create_joint_control_panel()  # 新增關節微調面板
             with ui.column().classes('w-2/3'):
                 self._create_status_display()
                 self._create_onnx_display()
@@ -97,6 +98,21 @@ class UIController:
             ).props('throttle')
             ui.button('清除命令 (Clear Command)', on_click=self.state.clear_command).props('outline')
 
+    def _create_joint_control_panel(self):
+        """在 JOINT_TEST 或 MANUAL_CTRL 模式下顯示的關節微調面板。"""
+        with ui.card().bind_visibility_from(self.state, 'control_mode', lambda m: m in ["JOINT_TEST", "MANUAL_CTRL"]).classes('w-full'):
+            ui.label('關節微調 (Joint Fine-Tuning)').classes('text-lg')
+            joint_names = {
+                0: 'FR_Abduction', 1: 'FR_Hip', 2: 'FR_Knee', 3: 'FL_Abduction', 4: 'FL_Hip', 5: 'FL_Knee',
+                6: 'RR_Abduction', 7: 'RR_Hip', 8: 'RR_Knee', 9: 'RL_Abduction', 10: 'RL_Hip', 11: 'RL_Knee'
+            }
+            ui.select(joint_names, label='選擇關節', on_change=lambda e: self._set_joint_index(int(e.value)))
+            self.status_labels['joint_info'] = ui.label('')
+            with ui.row():
+                ui.button('-', on_click=lambda: self._adjust_joint_value(-0.1))
+                ui.button('+', on_click=lambda: self._adjust_joint_value(0.1))
+                ui.button('歸零 (Clear)', on_click=lambda: self._adjust_joint_value(0, clear=True))
+
     def _create_status_display(self):
         with ui.card():
             ui.label('即時狀態 (Real-time Status)').classes('text-lg')
@@ -147,6 +163,15 @@ class UIController:
             self.status_labels['command'].set_text(f"vy: {cmd[0]:.2f}, vx: {cmd[1]:.2f}, wz: {cmd[2]:.2f}")
             pos = self.state.latest_pos
             self.status_labels['robot_pos'].set_text(f"位置: [{pos[0]:.2f}, {pos[1]:.2f}, {pos[2]:.2f}]")
+            # 更新關節資訊顯示
+            if self.state.control_mode in ["JOINT_TEST", "MANUAL_CTRL"]:
+                if self.state.control_mode == "JOINT_TEST":
+                    idx = self.state.joint_test_index
+                    val = self.state.joint_test_offsets[idx]
+                else:
+                    idx = self.state.manual_ctrl_index
+                    val = self.state.manual_final_ctrl[idx]
+                self.status_labels['joint_info'].set_text(f"關節 {idx}: {val:+.2f}")
             pm = self.policy_manager
             if pm.is_transitioning:
                 alpha_percent = pm.transition_alpha * 100
@@ -199,6 +224,30 @@ class UIController:
             is_connected = self.xbox_handler.scan_and_connect()
             with self.state.lock:
                 self.state.gamepad_is_connected = is_connected
+
+    def _set_joint_index(self, index: int):
+        """設定目前選中的關節索引。"""
+        with self.state.lock:
+            if self.state.control_mode == "JOINT_TEST":
+                self.state.joint_test_index = index
+            elif self.state.control_mode == "MANUAL_CTRL":
+                self.state.manual_ctrl_index = index
+
+    def _adjust_joint_value(self, value: float, clear: bool = False):
+        """依目前模式調整關節值或歸零。"""
+        with self.state.lock:
+            if self.state.control_mode == "JOINT_TEST":
+                idx = self.state.joint_test_index
+                if clear:
+                    self.state.joint_test_offsets[idx] = 0.0
+                else:
+                    self.state.joint_test_offsets[idx] += value
+            elif self.state.control_mode == "MANUAL_CTRL":
+                idx = self.state.manual_ctrl_index
+                if clear:
+                    self.state.manual_final_ctrl[idx] = 0.0
+                else:
+                    self.state.manual_final_ctrl[idx] += value
 
     def _update_command_from_joystick(self, event):
         x_val = -event.args.y / 50.0

--- a/ui_controller.py
+++ b/ui_controller.py
@@ -90,10 +90,10 @@ class UIController:
         with ui.card().classes('w-full'):
             ui.label('手動駕駛 (Manual Driving)').classes('text-lg')
             ui.joystick(
-                color='blue',
-                size=100,
-                on_move=lambda e: self._update_command_from_joystick(e),
-                on_end=self._on_joystick_end  # 直接傳遞方法
+                color='blue', 
+                size=100, 
+                on_move=self._update_command_from_joystick,  # 直接傳遞回呼函式
+                on_end=self._on_joystick_end
             ).props('throttle')
             ui.button('清除命令 (Clear Command)', on_click=self.state.clear_command).props('outline')
 
@@ -249,8 +249,9 @@ class UIController:
                     self.state.manual_final_ctrl[idx] += value
 
     def _update_command_from_joystick(self, event):
-        x_val = -event.args.y / 50.0
-        y_val = event.args.x / 50.0
+        """虛擬搖桿移動時的回呼函式，根據 x、y 更新指令。"""
+        x_val = -event.y / 50.0  # y 值對應機器人前後速度，方向相反
+        y_val = event.x / 50.0   # x 值對應左右橫移速度
         # 切換到虛擬搖桿輸入模式，但保留當前指令
         self.state.toggle_input_mode("VJOY", clear_cmd=False)
         with self.state.lock:

--- a/ui_controller.py
+++ b/ui_controller.py
@@ -1,40 +1,39 @@
-"""NiceGUI based control panel."""
-
-from typing import TYPE_CHECKING
-
 from nicegui import ui
 import numpy as np
+from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:  # pragma: no cover - type hints
+from logger import log, log_queue
+
+if TYPE_CHECKING:
     from state import SimulationState
 
-
 class UIController:
-    """Encapsulate all NiceGUI layout and callbacks."""
-
-    def __init__(self, state: 'SimulationState') -> None:
+    """管理 NiceGUI 介面與互動邏輯。"""
+    def __init__(self, state: 'SimulationState'):
         self.state = state
         self.policy_manager = state.policy_manager_ref
         self.hardware_controller = state.hardware_controller_ref
         self.serial_comm = state.serial_communicator_ref
         self.xbox_handler = state.xbox_handler_ref
 
-        self.status_labels: dict[str, ui.label] = {}
-        self.param_sliders: dict[str, ui.slider] = {}
-        self.onnx_input_labels: dict[str, ui.label] = {}
-        self.log_area: ui.textarea | None = None
+        self.status_labels = {}
+        self.param_sliders = {}
+        self.onnx_input_labels = {}
+        self.log_area = None
+        self.serial_command_buffer = None
 
         self._setup_ui()
 
-    def _setup_ui(self) -> None:
+    def _setup_ui(self):
         ui.dark_mode().enable()
-        with ui.header(elevated=True).style('background-color: #3874c8'):
+        with ui.header(elevated=True).style('background-color: #3874c8').classes('items-center justify-between'):
             ui.label('Pupper 機器人控制台').classes('text-lg')
 
         with ui.row().classes('w-full no-wrap'):
             with ui.column().classes('w-1/3'):
                 self._create_control_panel()
                 self._create_tuning_panel()
+                self._create_joystick_panel()
             with ui.column().classes('w-2/3'):
                 self._create_status_display()
                 self._create_onnx_display()
@@ -42,8 +41,7 @@ class UIController:
 
         ui.timer(0.1, self.update_ui_elements)
 
-
-    def _create_control_panel(self) -> None:
+    def _create_control_panel(self):
         with ui.card():
             ui.label('模式控制 (Control Mode)').classes('text-lg')
             with ui.row():
@@ -56,8 +54,7 @@ class UIController:
 
             ui.separator()
             ui.label('硬體 AI 控制').classes('text-lg')
-            ui.button('啟用/停用 AI (K)', on_click=self._toggle_hardware_ai).bind_enabled_from(
-                self.state, 'control_mode', lambda m: m == "HARDWARE_MODE")
+            ui.button('啟用/停用 AI (K)', on_click=self._toggle_hardware_ai).bind_enabled_from(self.state, 'control_mode', lambda mode: mode == "HARDWARE_MODE")
 
             ui.separator()
             ui.label('設備與重置').classes('text-lg')
@@ -68,15 +65,15 @@ class UIController:
                 ui.button('軟重置 (X)', on_click=lambda: self.set_request_flag('soft_reset_requested'))
                 ui.button('硬重置 (R)', on_click=lambda: self.set_request_flag('hard_reset_requested'))
 
-    def _create_tuning_panel(self) -> None:
+    def _create_tuning_panel(self):
         with ui.card().classes('w-full'):
             ui.label('參數調整 (Tuning)').classes('text-lg')
             params = self.state.tuning_params
             p_keys = {'kp': (0, 50), 'kd': (0, 5), 'action_scale': (0, 2), 'bias': (-20, 20)}
-            for key, (mn, mx) in p_keys.items():
+            for key, (min_val, max_val) in p_keys.items():
                 with ui.row().classes('w-full items-center'):
                     ui.label(key.upper()).classes('w-20')
-                    ui.slider(min=mn, max=mx, step=0.01, value=getattr(params, key)).bind_value(params, key).classes('w-48')
+                    slider = ui.slider(min=min_val, max=max_val, step=0.01, value=getattr(params, key)).bind_value(params, key).classes('w-48')
                     ui.label().bind_text_from(params, key, lambda v: f'{v:.2f}')
 
             ui.separator()
@@ -88,7 +85,15 @@ class UIController:
                 on_change=lambda e: self.policy_manager.select_target_policy(e.value)
             ).classes('w-full')
 
-    def _create_status_display(self) -> None:
+    def _create_joystick_panel(self):
+        with ui.card().classes('w-full'):
+            ui.label('手動駕駛 (Manual Driving)').classes('text-lg')
+            ui.joystick(color='blue', size=100,
+                        on_move=lambda e: self._update_command_from_joystick(e),
+                        on_end=lambda e: self.state.clear_command()).props('throttle')
+            ui.button('清除命令', on_click=self.state.clear_command).props('outline')
+
+    def _create_status_display(self):
         with ui.card():
             ui.label('即時狀態 (Real-time Status)').classes('text-lg')
             with ui.grid(columns=3):
@@ -99,81 +104,64 @@ class UIController:
                 self.status_labels['gamepad_status'] = ui.label('搖桿: Disconnected')
                 self.status_labels['hardware_ai'] = ui.label('硬體AI: N/A')
                 self.status_labels['policy_status'] = ui.label(f'策略: {self.policy_manager.primary_policy_name}')
-
             ui.separator()
             ui.label('運動指令 (Command)').classes('font-bold')
             self.status_labels['command'] = ui.label('vy: 0.00, vx: 0.00, wz: 0.00')
-
             ui.label('機器人狀態 (Robot State)').classes('font-bold')
             self.status_labels['robot_pos'] = ui.label('位置: [0.0, 0.0, 0.0]')
             self.status_labels['robot_vel'] = ui.label('速度: [0.0, 0.0, 0.0]')
 
-    def _create_onnx_display(self) -> None:
+    def _create_onnx_display(self):
         with ui.card().classes('w-full'):
             ui.label('ONNX 觀察向量 (Observation Vector)').classes('text-lg')
             with ui.grid(columns=2):
-                obs_components = [
-                    'linear_velocity', 'angular_velocity', 'gravity_vector', 'commands',
-                    'accelerometer', 'joint_positions', 'joint_velocities', 'last_action'
-                ]
+                obs_components = ['linear_velocity', 'angular_velocity', 'gravity_vector', 'commands',
+                                  'accelerometer', 'joint_positions', 'joint_velocities', 'last_action']
                 for comp in obs_components:
                     self.onnx_input_labels[comp] = ui.label(f'{comp}: N/A')
 
-    def _create_log_panel(self) -> None:
+    def _create_log_panel(self):
         with ui.card().classes('w-full'):
-            ui.label('日誌輸出 (Log Output)').classes('text-lg')
-            # "rows=10" 用於設定顯示高度，取代錯誤的 .lines()
+            ui.label('系統日誌與序列埠控制台').classes('text-lg')
             self.log_area = ui.textarea(label='Log').props('readonly outlined rows=10').style('width: 100%;')
+            with ui.row().classes('w-full items-center'):
+                self.serial_command_buffer = ui.input(label='Serial Command').props('outlined dense').classes('flex-grow')
+                ui.button('Send', on_click=self._send_serial_command)
 
-    # ------------------------------------------------------------------
-    def update_ui_elements(self) -> None:
+    def update_ui_elements(self):
         with self.state.lock:
-            self.status_labels['mode'].text = f"模式: {self.state.control_mode}"
-            self.status_labels['input_mode'].text = f"輸入: {self.state.input_mode}"
-            if self.state.sim:
-                self.status_labels['sim_time'].text = f"時間: {self.state.sim.data.time:.2f}s"
-            self.status_labels['serial_status'].text = (
-                '序列埠: Connected' if self.state.serial_is_connected else '序列埠: Disconnected'
-            )
-            self.status_labels['gamepad_status'].text = (
-                '搖桿: Connected' if self.state.gamepad_is_connected else '搖桿: Disconnected'
-            )
+            self.status_labels['mode'].set_text(f"模式: {self.state.control_mode}")
+            self.status_labels['input_mode'].set_text(f"輸入: {self.state.input_mode}")
+            self.status_labels['sim_time'].set_text(f"時間: {self.state.sim.data.time:.2f}s" if self.state.sim else "時間: N/A")
+            self.status_labels['serial_status'].set_text('序列埠: Connected' if self.state.serial_is_connected else '序列埠: Disconnected')
+            self.status_labels['gamepad_status'].set_text('搖桿: Connected' if self.state.gamepad_is_connected else '搖桿: Disconnected')
             if self.state.control_mode == 'HARDWARE_MODE':
-                self.status_labels['hardware_ai'].text = '硬體AI: Active' if self.state.hardware_ai_is_active else '硬體AI: Disabled'
+                self.status_labels['hardware_ai'].set_text('硬體AI: Active' if self.state.hardware_ai_is_active else '硬體AI: Disabled')
             else:
-                self.status_labels['hardware_ai'].text = '硬體AI: N/A'
-
+                self.status_labels['hardware_ai'].set_text('硬體AI: N/A')
             cmd = self.state.command
-            self.status_labels['command'].text = f"vy: {cmd[0]:.2f}, vx: {cmd[1]:.2f}, wz: {cmd[2]:.2f}"
-
+            self.status_labels['command'].set_text(f"vy: {cmd[0]:.2f}, vx: {cmd[1]:.2f}, wz: {cmd[2]:.2f}")
             pos = self.state.latest_pos
-            self.status_labels['robot_pos'].text = f"位置: [{pos[0]:.2f}, {pos[1]:.2f}, {pos[2]:.2f}]"
-
+            self.status_labels['robot_pos'].set_text(f"位置: [{pos[0]:.2f}, {pos[1]:.2f}, {pos[2]:.2f}]")
             pm = self.policy_manager
             if pm.is_transitioning:
                 alpha_percent = pm.transition_alpha * 100
                 policy_text = f"策略: Blending {pm.source_policy_name} -> {pm.target_policy_name} ({alpha_percent:.0f}%)"
             else:
                 policy_text = f"策略: {pm.primary_policy_name}"
-            self.status_labels['policy_status'].text = policy_text
-            self.status_labels['policy_selector'].value = pm.primary_policy_name
-
+            self.status_labels['policy_status'].set_text(policy_text)
+            self.status_labels['policy_selector'].set_value(pm.primary_policy_name)
             self._update_onnx_labels()
+        log_content = "\n".join(log_queue)
+        self.log_area.set_value(log_content)
 
-            if self.state.control_mode == 'SERIAL_MODE':
-                self.log_area.value = "\n".join(self.state.serial_latest_messages)
-            else:
-                self.log_area.value = self.state.hardware_status_text if self.state.control_mode == 'HARDWARE_MODE' else ''
-
-    def _update_onnx_labels(self) -> None:
+    def _update_onnx_labels(self):
         if self.state.latest_onnx_input.size == 0 or not self.policy_manager.get_active_recipe():
             return
-
         recipe = self.policy_manager.get_active_recipe()
         obs_vec = self.state.latest_onnx_input
         current_idx = 0
-        component_dims = self.policy_manager.obs_builder.component_dims
-
+        component_dims = self.state.policy_manager.obs_builder.component_dims
         for comp_name in recipe:
             dim = component_dims.get(comp_name, 0)
             if dim > 0 and comp_name in self.onnx_input_labels:
@@ -181,31 +169,48 @@ class UIController:
                 if end_idx <= len(obs_vec):
                     value_slice = obs_vec[current_idx:end_idx]
                     vec_str = np.array2string(value_slice, precision=2, suppress_small=True, max_line_width=30)
-                    self.onnx_input_labels[comp_name].text = f'{comp_name}: {vec_str}'
+                    self.onnx_input_labels[comp_name].set_text(f'{comp_name}: {vec_str}')
                 current_idx = end_idx
 
-    # ------------------------------------------------------------------
-    def _toggle_hardware_ai(self) -> None:
+    def _toggle_hardware_ai(self):
         if self.hardware_controller and self.state.control_mode == 'HARDWARE_MODE':
             if self.state.hardware_ai_is_active:
                 self.hardware_controller.disable_ai()
             else:
                 self.hardware_controller.enable_ai()
 
-    def set_request_flag(self, flag_name: str) -> None:
+    def set_request_flag(self, flag_name: str):
         with self.state.lock:
             setattr(self.state, flag_name, True)
 
-    def _connect_serial(self) -> None:
+    def _connect_serial(self):
         if self.serial_comm:
-            connected = self.serial_comm.scan_and_connect()
+            is_connected = self.serial_comm.scan_and_connect()
             with self.state.lock:
-                self.state.serial_is_connected = connected
+                self.state.serial_is_connected = is_connected
 
-    def _connect_gamepad(self) -> None:
+    def _connect_gamepad(self):
         if self.xbox_handler:
-            connected = self.xbox_handler.scan_and_connect()
+            is_connected = self.xbox_handler.scan_and_connect()
             with self.state.lock:
-                self.state.gamepad_is_connected = connected
+                self.state.gamepad_is_connected = is_connected
 
+    def _update_command_from_joystick(self, event):
+        x_val = -event.args.y / 50.0
+        y_val = event.args.x / 50.0
+        with self.state.lock:
+            if self.state.input_mode != "GAMEPAD":
+                self.state.input_mode = "GAMEPAD"
+            self.state.command[0] = y_val * self.state.config.gamepad_sensitivity['vy']
+            self.state.command[1] = x_val * self.state.config.gamepad_sensitivity['vx']
+            self.state.command[2] = 0.0
 
+    def _send_serial_command(self):
+        command_text = self.serial_command_buffer.value
+        if self.serial_comm and command_text:
+            self.serial_comm.send_command(command_text)
+            self.serial_command_buffer.set_value('')
+            log.info(f"> {command_text}")
+
+    def run(self):
+        ui.run(title="Pupper Robot Console", port=8080)

--- a/ui_controller.py
+++ b/ui_controller.py
@@ -250,8 +250,8 @@ class UIController:
 
     def _update_command_from_joystick(self, event):
         """虛擬搖桿移動時的回呼函式，根據 x、y 更新指令。"""
-        x_val = -event.y / 50.0  # y 值對應機器人前後速度，方向相反
-        y_val = event.x / 50.0   # x 值對應左右橫移速度
+        x_val = -event.y #/ 50.0  # y 值對應機器人前後速度，方向相反
+        y_val = event.x #/ 50.0   # x 值對應左右橫移速度
         # 切換到虛擬搖桿輸入模式，但保留當前指令
         self.state.toggle_input_mode("VJOY", clear_cmd=False)
         with self.state.lock:

--- a/ui_controller.py
+++ b/ui_controller.py
@@ -4,19 +4,16 @@ from typing import TYPE_CHECKING
 
 from nicegui import ui
 import numpy as np
-import threading
 
 if TYPE_CHECKING:  # pragma: no cover - type hints
     from state import SimulationState
-    from simulation_controller import SimulationController
 
 
 class UIController:
     """Encapsulate all NiceGUI layout and callbacks."""
 
-    def __init__(self, state: 'SimulationState', simulation_controller: 'SimulationController') -> None:
+    def __init__(self, state: 'SimulationState') -> None:
         self.state = state
-        self.simulation_controller = simulation_controller  # 儲存模擬控制器參考
         self.policy_manager = state.policy_manager_ref
         self.hardware_controller = state.hardware_controller_ref
         self.serial_comm = state.serial_communicator_ref
@@ -28,18 +25,6 @@ class UIController:
         self.log_area: ui.textarea | None = None
 
         self._setup_ui()
-
-    # -----------------------------------------------------------
-    def handle_startup(self) -> None:
-        """在 NiceGUI 啟動後執行，啟動模擬執行緒。"""
-        print("NiceGUI 已啟動，啟動模擬執行緒...")
-        thread = threading.Thread(target=self.simulation_controller.run, daemon=True)
-        thread.start()
-
-    def handle_shutdown(self) -> None:
-        """在 NiceGUI 關閉時執行，停止模擬執行緒。"""
-        print("NiceGUI 即將關閉，停止模擬執行緒...")
-        self.simulation_controller.stop()
 
     def _setup_ui(self) -> None:
         ui.dark_mode().enable()

--- a/ui_controller.py
+++ b/ui_controller.py
@@ -4,16 +4,19 @@ from typing import TYPE_CHECKING
 
 from nicegui import ui
 import numpy as np
+import threading
 
 if TYPE_CHECKING:  # pragma: no cover - type hints
     from state import SimulationState
+    from simulation_controller import SimulationController
 
 
 class UIController:
     """Encapsulate all NiceGUI layout and callbacks."""
 
-    def __init__(self, state: 'SimulationState') -> None:
+    def __init__(self, state: 'SimulationState', simulation_controller: 'SimulationController') -> None:
         self.state = state
+        self.simulation_controller = simulation_controller  # 儲存模擬控制器參考
         self.policy_manager = state.policy_manager_ref
         self.hardware_controller = state.hardware_controller_ref
         self.serial_comm = state.serial_communicator_ref
@@ -41,6 +44,25 @@ class UIController:
                 self._create_log_panel()
 
         ui.timer(0.1, self.update_ui_elements)
+        # 註冊 NiceGUI 的生命週期事件，確保模擬執行緒在 UI 啟動後再啟動
+        self._setup_lifecycle_events()
+
+    def _setup_lifecycle_events(self) -> None:
+        """設定 NiceGUI 的啟動與關閉事件，用來管理背景模擬執行緒。"""
+
+        def start_simulation_thread() -> None:
+            """在 UI 完全啟動後啟動模擬執行緒。"""
+            print("NiceGUI 已啟動，啟動模擬執行緒...")
+            thread = threading.Thread(target=self.simulation_controller.run, daemon=True)
+            thread.start()
+
+        def stop_simulation_thread() -> None:
+            """在 UI 關閉時停止模擬執行緒。"""
+            print("NiceGUI 即將關閉，停止模擬執行緒...")
+            self.simulation_controller.stop()
+
+        ui.on_startup(start_simulation_thread)
+        ui.on_shutdown(stop_simulation_thread)
 
     def _create_control_panel(self) -> None:
         with ui.card():

--- a/ui_controller.py
+++ b/ui_controller.py
@@ -29,6 +29,18 @@ class UIController:
 
         self._setup_ui()
 
+    # -----------------------------------------------------------
+    def handle_startup(self) -> None:
+        """在 NiceGUI 啟動後執行，啟動模擬執行緒。"""
+        print("NiceGUI 已啟動，啟動模擬執行緒...")
+        thread = threading.Thread(target=self.simulation_controller.run, daemon=True)
+        thread.start()
+
+    def handle_shutdown(self) -> None:
+        """在 NiceGUI 關閉時執行，停止模擬執行緒。"""
+        print("NiceGUI 即將關閉，停止模擬執行緒...")
+        self.simulation_controller.stop()
+
     def _setup_ui(self) -> None:
         ui.dark_mode().enable()
         with ui.header(elevated=True).style('background-color: #3874c8'):
@@ -44,25 +56,7 @@ class UIController:
                 self._create_log_panel()
 
         ui.timer(0.1, self.update_ui_elements)
-        # 註冊 NiceGUI 的生命週期事件，確保模擬執行緒在 UI 啟動後再啟動
-        self._setup_lifecycle_events()
 
-    def _setup_lifecycle_events(self) -> None:
-        """設定 NiceGUI 的啟動與關閉事件，用來管理背景模擬執行緒。"""
-
-        def start_simulation_thread() -> None:
-            """在 UI 完全啟動後啟動模擬執行緒。"""
-            print("NiceGUI 已啟動，啟動模擬執行緒...")
-            thread = threading.Thread(target=self.simulation_controller.run, daemon=True)
-            thread.start()
-
-        def stop_simulation_thread() -> None:
-            """在 UI 關閉時停止模擬執行緒。"""
-            print("NiceGUI 即將關閉，停止模擬執行緒...")
-            self.simulation_controller.stop()
-
-        ui.on_startup(start_simulation_thread)
-        ui.on_shutdown(stop_simulation_thread)
 
     def _create_control_panel(self) -> None:
         with ui.card():
@@ -229,6 +223,4 @@ class UIController:
             with self.state.lock:
                 self.state.gamepad_is_connected = connected
 
-    def run(self) -> None:
-        ui.run(title="Pupper Robot Console", port=8080)
 

--- a/xbox_controller.py
+++ b/xbox_controller.py
@@ -5,10 +5,12 @@ class XboxController:
     """
     一個使用 Pygame 函式庫來讀取 Xbox 搖桿輸入的類別。
     這個版本是非阻塞的，可以安全地在主迴圈中更新。
+    由於 Pygame 的事件系統必須在初始化它的執行緒中運作，
+    因此真正的 `pygame.init()` 將由模擬執行緒呼叫 :func:`initialize` 完成。
     """
+
     def __init__(self):
-        """初始化 Pygame 但不立即掃描搖桿。"""
-        pygame.init()
+        """僅設定初始狀態，不立即初始化 Pygame。"""
         self.joystick = None
         self.deadzone = 0.15
         self.state = {
@@ -19,7 +21,18 @@ class XboxController:
             'button_l1': 0, 'button_r1': 0,
             'button_select': 0, 'button_start': 0,
         }
-        print("✅ XBox 控制器已初始化 (等待連接指令)。")
+        print("✅ XBox Controller 物件已建立 (等待執行緒初始化)。")
+
+    def initialize(self) -> bool:
+        """在當前執行緒中初始化 Pygame 與搖桿模組。"""
+        try:
+            pygame.init()
+            pygame.joystick.init()
+            print("✅ Pygame 在模擬執行緒中初始化完成。")
+            return True
+        except pygame.error as e:
+            print(f"❌ Pygame 初始化失敗: {e}")
+            return False
 
     def scan_and_connect(self) -> bool:
         """掃描並連接到第一個可用的搖桿。"""
@@ -28,7 +41,9 @@ class XboxController:
             return True
 
         print("\n" + "="*20 + " 正在掃描搖桿 " + "="*20)
-        pygame.joystick.init() # 每次掃描時重新初始化
+        # 重新初始化搖桿子系統，確保能偵測到新插入的設備
+        pygame.joystick.quit()
+        pygame.joystick.init()
         
         if pygame.joystick.get_count() > 0:
             self.joystick = pygame.joystick.Joystick(0)

--- a/xbox_controller.py
+++ b/xbox_controller.py
@@ -66,36 +66,40 @@ class XboxController:
         """處理 Pygame 事件佇列，更新搖桿狀態。"""
         if not self.is_connected():
             return
-            
+
         try:
             for event in pygame.event.get():
                 if event.type == pygame.JOYAXISMOTION:
-                    if event.axis == 0: self.state['left_analog_x'] = event.value
-                    elif event.axis == 1: self.state['left_analog_y'] = event.value
-                    elif event.axis == 2: self.state['right_analog_x'] = event.value
-                    elif event.axis == 3: self.state['right_analog_y'] = event.value
+                    # 只處理我們認識的軸索引，其餘忽略
+                    if event.axis == 0:
+                        self.state['left_analog_x'] = event.value
+                    elif event.axis == 1:
+                        self.state['left_analog_y'] = event.value
+                    elif event.axis == 2:
+                        self.state['right_analog_x'] = event.value
+                    elif event.axis == 3:
+                        self.state['right_analog_y'] = event.value
                 elif event.type == pygame.JOYBUTTONDOWN:
-                    if event.button == 0: self.state['button_a'] = 1
-                    elif event.button == 1: self.state['button_b'] = 1
-                    elif event.button == 2: self.state['button_x'] = 1
-                    elif event.button == 3: self.state['button_y'] = 1
-                    elif event.button == 4: self.state['button_l1'] = 1
-                    elif event.button == 5: self.state['button_r1'] = 1
-                    elif event.button == 6: self.state['button_select'] = 1
-                    elif event.button == 7: self.state['button_start'] = 1
+                    # 使用映射表處理，避免未知索引導致 KeyError
+                    button_map = {
+                        0: 'button_a', 1: 'button_b', 2: 'button_x', 3: 'button_y',
+                        4: 'button_l1', 5: 'button_r1', 6: 'button_select', 7: 'button_start'
+                    }
+                    if event.button in button_map:
+                        self.state[button_map[event.button]] = 1
                 elif event.type == pygame.JOYBUTTONUP:
-                    if event.button == 0: self.state['button_a'] = 0
-                    elif event.button == 1: self.state['button_b'] = 0
-                    elif event.button == 2: self.state['button_x'] = 0
-                    elif event.button == 3: self.state['button_y'] = 0
-                    elif event.button == 4: self.state['button_l1'] = 0
-                    elif event.button == 5: self.state['button_r1'] = 0
-                    elif event.button == 6: self.state['button_select'] = 0
-                    elif event.button == 7: self.state['button_start'] = 0
+                    button_map = {
+                        0: 'button_a', 1: 'button_b', 2: 'button_x', 3: 'button_y',
+                        4: 'button_l1', 5: 'button_r1', 6: 'button_select', 7: 'button_start'
+                    }
+                    if event.button in button_map:
+                        self.state[button_map[event.button]] = 0
                 elif event.type == pygame.JOYHATMOTION:
-                    self.state['dpad'] = event.value
+                    # 部分控制器可能有多個 hat，這裡僅處理第一個
+                    if hasattr(event, 'hat') and event.hat == 0:
+                        self.state['dpad'] = event.value
         except pygame.error as e:
-            # 當系統焦點改變時，事件處理可能失敗，此處捕獲並警告
+            # 在某些情況下（例如視窗失去焦點），事件處理可能會失敗，我們在此捕獲錯誤以避免程式崩潰
             print(f"⚠️ Pygame 事件處理時發生錯誤: {e}")
 
     def get_input(self) -> dict:

--- a/xbox_controller.py
+++ b/xbox_controller.py
@@ -27,8 +27,11 @@ class XboxController:
         """在當前執行緒中初始化 Pygame 與搖桿模組。"""
         try:
             pygame.init()
+            # 【關鍵修正】建立一個 1x1 的不可見視窗，
+            # 以確保 pygame 的事件系統穩定運作。
+            pygame.display.set_mode((1, 1), pygame.NOFRAME)
             pygame.joystick.init()
-            print("✅ Pygame 在模擬執行緒中初始化完成。")
+            print("✅ Pygame 在模擬執行緒中初始化完成 (含虛擬視窗)。")
             return True
         except pygame.error as e:
             print(f"❌ Pygame 初始化失敗: {e}")
@@ -64,32 +67,36 @@ class XboxController:
         if not self.is_connected():
             return
             
-        for event in pygame.event.get():
-            if event.type == pygame.JOYAXISMOTION:
-                if event.axis == 0: self.state['left_analog_x'] = event.value
-                elif event.axis == 1: self.state['left_analog_y'] = event.value
-                elif event.axis == 2: self.state['right_analog_x'] = event.value
-                elif event.axis == 3: self.state['right_analog_y'] = event.value
-            elif event.type == pygame.JOYBUTTONDOWN:
-                if event.button == 0: self.state['button_a'] = 1
-                elif event.button == 1: self.state['button_b'] = 1
-                elif event.button == 2: self.state['button_x'] = 1
-                elif event.button == 3: self.state['button_y'] = 1
-                elif event.button == 4: self.state['button_l1'] = 1
-                elif event.button == 5: self.state['button_r1'] = 1
-                elif event.button == 6: self.state['button_select'] = 1
-                elif event.button == 7: self.state['button_start'] = 1
-            elif event.type == pygame.JOYBUTTONUP:
-                if event.button == 0: self.state['button_a'] = 0
-                elif event.button == 1: self.state['button_b'] = 0
-                elif event.button == 2: self.state['button_x'] = 0
-                elif event.button == 3: self.state['button_y'] = 0
-                elif event.button == 4: self.state['button_l1'] = 0
-                elif event.button == 5: self.state['button_r1'] = 0
-                elif event.button == 6: self.state['button_select'] = 0
-                elif event.button == 7: self.state['button_start'] = 0
-            elif event.type == pygame.JOYHATMOTION:
-                self.state['dpad'] = event.value
+        try:
+            for event in pygame.event.get():
+                if event.type == pygame.JOYAXISMOTION:
+                    if event.axis == 0: self.state['left_analog_x'] = event.value
+                    elif event.axis == 1: self.state['left_analog_y'] = event.value
+                    elif event.axis == 2: self.state['right_analog_x'] = event.value
+                    elif event.axis == 3: self.state['right_analog_y'] = event.value
+                elif event.type == pygame.JOYBUTTONDOWN:
+                    if event.button == 0: self.state['button_a'] = 1
+                    elif event.button == 1: self.state['button_b'] = 1
+                    elif event.button == 2: self.state['button_x'] = 1
+                    elif event.button == 3: self.state['button_y'] = 1
+                    elif event.button == 4: self.state['button_l1'] = 1
+                    elif event.button == 5: self.state['button_r1'] = 1
+                    elif event.button == 6: self.state['button_select'] = 1
+                    elif event.button == 7: self.state['button_start'] = 1
+                elif event.type == pygame.JOYBUTTONUP:
+                    if event.button == 0: self.state['button_a'] = 0
+                    elif event.button == 1: self.state['button_b'] = 0
+                    elif event.button == 2: self.state['button_x'] = 0
+                    elif event.button == 3: self.state['button_y'] = 0
+                    elif event.button == 4: self.state['button_l1'] = 0
+                    elif event.button == 5: self.state['button_r1'] = 0
+                    elif event.button == 6: self.state['button_select'] = 0
+                    elif event.button == 7: self.state['button_start'] = 0
+                elif event.type == pygame.JOYHATMOTION:
+                    self.state['dpad'] = event.value
+        except pygame.error as e:
+            # 當系統焦點改變時，事件處理可能失敗，此處捕獲並警告
+            print(f"⚠️ Pygame 事件處理時發生錯誤: {e}")
 
     def get_input(self) -> dict:
         """獲取當前搖桿狀態的淺拷貝，並應用死區。"""


### PR DESCRIPTION
## Summary
- add `main_nicegui.py` with new entrypoint using NiceGUI
- create UI controller and background simulation controller
- add thread lock and references in `SimulationState`
- extend `Simulation` with thread-safe rendering
- simplify keyboard handler (moved mode switching to GUI)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688353772d1c832887306efdba8828ca