### PR TITLE
feat: support model output mode 支援模型輸出模式

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,8 +13,9 @@ mujoco_model_file: "assets/scene_mjx.xml"
 
 # ONNX 模型庫 (ONNX Model Library)
 onnx_models:
-  stable_walk: 
+  stable_walk:
     path: "models/pupper_ppo_policy_30965760_tf_converted_穩定步態版.onnx"
+    output_mode: "offset"  # 模型輸出為偏移量
     # 【新】為每個模型指定觀察配方
     observation_recipe:
       - 'linear_velocity'
@@ -25,9 +26,10 @@ onnx_models:
       - 'last_action'
       - 'commands'
   
-  agile_model: 
+  agile_model:
     path: "models/pupper_ppo_policy_200540160_tf_converted.onnx"
     # 假設 agile_model 使用與 stable_walk 相同的配方
+    output_mode: "offset"
     observation_recipe:
       - 'linear_velocity'
       - 'angular_velocity'
@@ -37,9 +39,10 @@ onnx_models:
       - 'last_action'
       - 'commands'
 
-  new_high_level: 
+  new_high_level:
     path: "models/pupper_ppo_policy_203161600_tf_v2.3_converted.onnx"
     # 【新】使用新的觀察配方
+    output_mode: "offset"
     observation_recipe:
       - 'angular_velocity'
       - 'gravity_vector'
@@ -49,8 +52,9 @@ onnx_models:
       - 'last_action'
       - 'commands'
 
-  new_e2e: 
+  new_e2e:
     path: "models/pupper_ppo_policy_e2e_203161600.onnx"
+    output_mode: "absolute"  # 此模型直接輸出絕對角度
     # e2e 模型也使用新的觀察配方
     observation_recipe:
       - 'angular_velocity'

--- a/hardware_controller.py
+++ b/hardware_controller.py
@@ -274,8 +274,14 @@ class HardwareController:
                     # 【保留】更新 last_action
                     self.hw_state.last_action[:] = action_raw
                 
-                # 【保留】生成發送給Teensy的文字指令
-                final_command = default_pose_hardware + action_raw * self.global_state.tuning_params.action_scale
+                # 【修改】根據模型設定決定最終控制模式
+                model_cfg = self.policy.get_active_model_config()  # 取得當前策略的設定
+                if model_cfg.get('output_mode') == 'absolute':
+                    # 若模型直接輸出絕對角度，則不加上 default pose
+                    final_command = action_raw * self.global_state.tuning_params.action_scale
+                else:
+                    # 預設為偏移量模式，需要加上 default pose
+                    final_command = default_pose_hardware + action_raw * self.global_state.tuning_params.action_scale
                 action_str = ' '.join(f"{a:.4f}" for a in final_command)
                 command_to_send = f"move all {action_str}\n"
 

--- a/policy.py
+++ b/policy.py
@@ -5,7 +5,7 @@ import sys
 import os
 import time
 from collections import deque
-from typing import TYPE_CHECKING, List, Dict
+from typing import TYPE_CHECKING, List, Dict, Any
 
 # 為了型別提示，避免循環匯入
 if TYPE_CHECKING:
@@ -117,6 +117,10 @@ class PolicyManager:
     def get_active_recipe(self) -> List[str]:
         """一個輔助函式，返回當前主要策略所使用的觀察配方，主要供 HardwareController 使用。"""
         return self.model_recipes.get(self.primary_policy_name, [])
+
+    def get_active_model_config(self) -> Dict[str, Any]:
+        """取得目前主策略的完整設定字典 (包含自訂 output_mode 等資訊)。"""
+        return self.config.onnx_models.get(self.primary_policy_name, {})
 
     def select_target_policy(self, target_name: str):
         """(由鍵盤觸發) 選擇一個目標策略並開始平滑轉換。"""

--- a/simulation_controller.py
+++ b/simulation_controller.py
@@ -217,7 +217,14 @@ class SimulationController:
             with self.state.lock:
                 final_ctrl = self.sim.default_pose + self.state.joint_test_offsets
         else:
-            final_ctrl = self.sim.default_pose + action_final * tuning_params.action_scale
+            # 【修改】根據模型的輸出模式決定是否加上 default pose
+            model_cfg = self.policy_manager.get_active_model_config()
+            if model_cfg.get('output_mode') == 'absolute':
+                # 模型輸出為絕對角度
+                final_ctrl = action_final * tuning_params.action_scale
+            else:
+                # 預設：模型輸出為偏移量
+                final_ctrl = self.sim.default_pose + action_final * tuning_params.action_scale
 
         self.sim.apply_position_control(final_ctrl, tuning_params)
 


### PR DESCRIPTION
## Summary
- add `output_mode` for each ONNX policy and expose via `PolicyManager`
- respect model's absolute vs offset outputs in simulation and hardware control

## Testing
- `python -m py_compile policy.py hardware_controller.py simulation_controller.py config.py`
- `pip install pyyaml` *(fails: Could not connect to proxy)*


------
https://chatgpt.com/codex/tasks/task_e_6890ac7dec6083289e5f3def12734ac0